### PR TITLE
Update HubSpot deal stage when sending invoice

### DIFF
--- a/manual-actions.php
+++ b/manual-actions.php
@@ -6,9 +6,11 @@
  */
 
 // Exit if accessed directly.
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+if ( ! defined( 'ABSPATH' ) ) {    if ($invoice_stage_id) {
+        update_hubspot_deal_stage($order_id, $invoice_stage_id);
+    }
+
+    log_email_in_hubspot($order_id, 'invoice');
 
 function send_invoice_email_ajax() {
     // Validate request


### PR DESCRIPTION
## Summary
- update invoice handler to move the HubSpot deal to the configured invoice stage
- always log the invoice email without stage id

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685b61c233448326b1e23061812ad2af