### PR TITLE
Fix license info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To remove the plugin:
 2. Click "Delete" to remove all associated data.
 
 ## License
-This plugin is licensed under **GPL-2.0**.
+This plugin is licensed under **GPL-3.0**.
 
 ## Support & Contributions
 For bug reports, feature requests, or contributions, visit the [GitHub Issues](https://github.com/weblifter/hubspot-woocommerce-sync/issues) page.


### PR DESCRIPTION
## Summary
- ensure README references GPL-3.0 consistently

## Testing
- `php -l` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b702aefd48326b0b3ad86839f577f