### PR TITLE
Update invoice stage sync

### DIFF
--- a/manual-actions.php
+++ b/manual-actions.php
@@ -8,14 +8,17 @@ add_action('wp_ajax_send_invoice_email', 'hubwoo_send_invoice_email_ajax');
 add_action('wp_ajax_manual_sync_hubspot_order', 'hubwoo_manual_sync_hubspot_order');
 function hubwoo_manual_sync_hubspot_order() {
     $dealstage_id = $deal['dealstage'] ?? '';
-    $pipeline_label = $labels['pipelines'][$pipeline_id] ?? $pipeline_id;
-if ( ! defined( 'ABSPATH' ) ) {    if ($invoice_stage_id) {
+    $pipeline_label = $labels['pipelines'][$pipeline_id] ?? $pipeline_id;    $type = order_type($order);
+    $invoice_stage_id = $type === 'manual'
+        ? get_option('hubspot_stage_invoice_sent_manual')
+        : get_option('hubspot_stage_invoice_sent_online');
+
+    if ($invoice_stage_id) {
         update_hubspot_deal_stage($order_id, $invoice_stage_id);
     }
 
     log_email_in_hubspot($order_id, 'invoice');
-
-function send_invoice_email_ajax() {
+
     // Validate request
     if (!isset($_POST['security']) || !wp_verify_nonce($_POST['security'], 'send_invoice_email_nonce')) {
         wp_send_json_error('Invalid security token.');

--- a/send-quote.php
+++ b/send-quote.php
@@ -88,9 +88,14 @@ add_action('wp_ajax_reset_quote_status', function () {
     $order->save();
 
     wp_send_json_success('Quote status reset.');
-});
-
-
+    $stage_id = get_option($stage_option);
+
+    if ($stage_id) {
+        update_hubspot_deal_stage($order->get_id(), $stage_id);
+    }
+
+    log_email_in_hubspot($order->get_id(), 'invoice');
+
 
 
 add_action('init', 'handle_quote_acceptance');


### PR DESCRIPTION
## Summary
- ensure invoice email ajax updates HubSpot stage
- keep invoice email logging simple
- update `send_invoice` to set stage before logging

## Testing
- `php -l manual-actions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b89f64b748326864860a0a8a06f70