### PR TITLE
Add capability checks to admin AJAX

### DIFF
--- a/abandoned-carts/admin-abandoned-carts.php
+++ b/abandoned-carts/admin-abandoned-carts.php
@@ -49,7 +49,11 @@ function render_abandoned_cart_admin_view() {
     // Cart Table
     if (!$carts) {
         echo '<p>No abandoned carts found for this filter.</p></div>';
-        return;
+add_action('wp_ajax_update_abandoned_cart_status', function () {
+    check_ajax_referer('hubspot_admin_nonce', 'security');
+    if ( ! current_user_can( 'manage_woocommerce' ) ) {
+        wp_send_json_error( 'Unauthorized', 403 );
+    }
     }
 
     echo '<table class="wp-list-table widefat fixed striped">';

--- a/abandoned-carts/email-templates.php
+++ b/abandoned-carts/email-templates.php
@@ -43,9 +43,17 @@ function render_hubspot_email_templates_page() {
         <h2>Saved Templates</h2>
         <table class="widefat">
             <thead><tr><th>Label</th><th>Subject</th><th>Actions</th></tr></thead>
-            <tbody id="template-list">
-                <?php foreach ($templates as $id => $tpl): ?>
-                    <tr data-id="<?= esc_attr($id) ?>"
+            <tbody id="template-list">add_action('wp_ajax_save_hubspot_email_template', function () {
+    check_ajax_referer('hubspot_email_template_nonce', 'security');
+    if ( ! current_user_can( 'manage_woocommerce' ) ) {
+        wp_send_json_error( 'Unauthorized', 403 );
+    }
+add_action('wp_ajax_delete_hubspot_email_template', function () {
+    check_ajax_referer('hubspot_email_template_nonce', 'security');
+    if ( ! current_user_can( 'manage_woocommerce' ) ) {
+        wp_send_json_error( 'Unauthorized', 403 );
+    }
+
                         data-label="<?= esc_attr($tpl['label']) ?>"
                         data-subject="<?= esc_attr($tpl['subject']) ?>"
                         data-body="<?= esc_attr($tpl['body']) ?>">

--- a/abandoned-carts/queue.php
+++ b/abandoned-carts/queue.php
@@ -1,4 +1,8 @@
-<?php
+add_action('wp_ajax_manually_trigger_abandoned_email', function () {
+    if ( ! current_user_can( 'manage_woocommerce' ) ) {
+        wp_send_json_error( 'Unauthorized', 403 );
+    }
+    global $wpdb;
 
 add_action('wp_ajax_manually_trigger_abandoned_email', function () {
     global $wpdb;

--- a/hubspot-functions.php
+++ b/hubspot-functions.php
@@ -16,8 +16,13 @@ function render_combined_order_management_page() {
     <div class="wrap">
         <h1>HubSpot Order Management</h1>
         <h2>Import Order from HubSpot</h2>
-        <form method="post" id="hubspot-import-form">
-            <input type="text" name="hubspot_deal_id" placeholder="Enter HubSpot Deal ID" required style="width: 300px;" />
+add_action('wp_ajax_import_hubspot_order', 'import_hubspot_order_ajax');
+function import_hubspot_order_ajax() {
+    check_ajax_referer('import_hubspot_order_nonce', 'security');
+    if ( ! current_user_can( 'manage_woocommerce' ) ) {
+        wp_send_json_error( 'Unauthorized', 403 );
+    }
+
             <input type="submit" class="button button-primary" value="Import Order">
         </form>
         <hr>

--- a/hubspot-settings.php
+++ b/hubspot-settings.php
@@ -206,8 +206,12 @@ class HubSpot_WC_Settings {
         if (is_wp_error($response)) {
             error_log("[HubSpot OAuth] ❌ API request failed: " . $response->get_error_message());
             return ['error' => 'Failed to fetch pipelines: ' . $response->get_error_message()];
-        }
-
+        }    public static function hubspot_check_connection() {
+        if ( ! current_user_can( 'manage_woocommerce' ) ) {
+            wp_send_json_error( 'Unauthorized', 403 );
+        }
+        global $wpdb;
+        $table_name = $wpdb->prefix . "hubspot_tokens";
         $body = json_decode(wp_remote_retrieve_body($response), true);
         error_log("[HubSpot OAuth] 🔍 Pipelines API Response: " . print_r($body, true));
 

--- a/manual-actions.php
+++ b/manual-actions.php
@@ -1,7 +1,23 @@
-<?php
-/**
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+    if ( ! current_user_can( 'manage_woocommerce' ) ) {
+        wp_send_json_error( 'Unauthorized', 403 );
+    }
+    $dealstage_id = $deal['dealstage'] ?? '';
+
+    if (!isset($_POST['security']) || !wp_verify_nonce($_POST['security'], 'send_invoice_email_nonce')) {
+        wp_send_json_error('Invalid security token.');
+    }
+    if ( ! current_user_can( 'manage_woocommerce' ) ) {
+        wp_send_json_error( 'Unauthorized', 403 );
+    }
+function manual_sync_hubspot_order() {
+    check_ajax_referer('manual_sync_hubspot_order_nonce', 'security');
+    if ( ! current_user_can( 'manage_woocommerce' ) ) {
+        wp_send_json_error( 'Unauthorized', 403 );
+    }
+    if ( ! current_user_can( 'manage_woocommerce' ) ) {
+        wp_send_json_error( 'Unauthorized', 403 );
+    }
+
 }
 function hubwoo_send_invoice_email_ajax() {
 add_action('wp_ajax_send_invoice_email', 'hubwoo_send_invoice_email_ajax');
@@ -86,7 +102,11 @@ function hubwoo_create_hubspot_deal_manual() {
     $dealstage_label = $labels['stages'][$dealstage_id] ?? $dealstage_id;
 
     // 🔄 Clear existing line and shipping items
-    foreach ($order->get_items() as $id => $item) $order->remove_item($id);
+function create_hubspot_deal_manual() {
+    check_ajax_referer('create_hubspot_deal_nonce', 'security');
+    if ( ! current_user_can( 'manage_woocommerce' ) ) {
+        wp_send_json_error( 'Unauthorized', 403 );
+    }
     foreach ($order->get_items('shipping') as $id => $item) $order->remove_item($id);
 
     // 📦 Billing

--- a/send-quote.php
+++ b/send-quote.php
@@ -1,4 +1,8 @@
-<?php
+    check_ajax_referer('send_quote_email_nonce', 'security');
+    if ( ! current_user_can( 'manage_woocommerce' ) ) {
+        wp_send_json_error( 'Unauthorized', 403 );
+    }
+
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -25,7 +29,11 @@ add_action('wp_ajax_send_quote_email', function () {
     check_ajax_referer('send_quote_email_nonce', 'security');
 
     $order_id = intval($_POST['order_id']);
-    $order = wc_get_order($order_id);
+add_action('wp_ajax_reset_quote_status', function () {
+    check_ajax_referer('reset_quote_status_nonce', 'security');
+    if ( ! current_user_can( 'manage_woocommerce' ) ) {
+        wp_send_json_error( 'Unauthorized', 403 );
+    }
     if (!$order) wp_send_json_error('Invalid Order ID.');
 
     $email = $order->get_billing_email();


### PR DESCRIPTION
## Summary
- enforce `manage_woocommerce` capability on all admin Ajax actions
- apply same check to abandoned carts handlers

## Testing
- `php -l manual-actions.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685b97a7e85483268d44adb6d737ed84