### PR TITLE
Implement plugin activation and deactivation hooks

### DIFF
--- a/hubspot-woocommerce-sync.php
+++ b/hubspot-woocommerce-sync.php
@@ -58,3 +58,40 @@ require_once HUBSPOT_WC_SYNC_PATH . 'hub-order-management.php';
 // Kick off the settings hooks
 HubSpot_WC_Settings::init();
 
+register_activation_hook( __FILE__, 'hubwoo_activation' );
+register_deactivation_hook( __FILE__, 'hubwoo_deactivation' );
+
+/**
+ * Plugin activation routine.
+ * Creates the hubspot_tokens table and schedules the token refresh event.
+ */
+function hubwoo_activation() {
+    global $wpdb;
+
+    $table_name      = $wpdb->prefix . 'hubspot_tokens';
+    $charset_collate = $wpdb->get_charset_collate();
+
+    $sql = "CREATE TABLE {$table_name} (
+        portal_id BIGINT(20) UNSIGNED NOT NULL,
+        access_token TEXT NOT NULL,
+        refresh_token TEXT NOT NULL,
+        expires_at BIGINT(20) UNSIGNED NOT NULL,
+        PRIMARY KEY  (portal_id)
+    ) {$charset_collate};";
+
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    dbDelta( $sql );
+
+    if ( ! wp_next_scheduled( 'hubspot_token_refresh_event' ) ) {
+        wp_schedule_event( time(), 'thirty_minutes', 'hubspot_token_refresh_event' );
+    }
+}
+
+/**
+ * Plugin deactivation routine.
+ * Clears the scheduled token refresh event.
+ */
+function hubwoo_deactivation() {
+    wp_clear_scheduled_hook( 'hubspot_token_refresh_event' );
+}
+


### PR DESCRIPTION
## Summary
- register activation/deactivation hooks in `hubspot-woocommerce-sync.php`
- create the `hubspot_tokens` table and schedule the token refresh event on activation
- clear the scheduled event on deactivation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685b9d5c4a7c83268fa638f4b24ee098