### PR TITLE
Add localization wrappers

### DIFF
--- a/hubspot-functions.php
+++ b/hubspot-functions.php
@@ -4,10 +4,14 @@ function hubwoo_import_hubspot_order_ajax() {
 
 add_action('wp_ajax_import_hubspot_order', 'hubwoo_import_hubspot_order_ajax');
 function hubwoo_import_hubspot_order_ajax() {
-    exit;
-}
-
-/*
+        <h1><?php esc_html_e( 'HubSpot Order Management', 'hub-woo-sync' ); ?></h1>
+        <h2><?php esc_html_e( 'Import Order from HubSpot', 'hub-woo-sync' ); ?></h2>
+        wp_send_json_error( __( 'Unauthorized', 'hub-woo-sync' ), 403 );
+
+            <input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Import Order', 'hub-woo-sync' ); ?>">
+    if (!$deal_id) wp_send_json_error( __( 'Missing HubSpot Deal ID.', 'hub-woo-sync' ) );
+    if (!$deal) wp_send_json_error( __( 'Failed to fetch deal data.', 'hub-woo-sync' ) );
+
 *
 * Render Order Management Page
 *

--- a/hubspot-settings.php
+++ b/hubspot-settings.php
@@ -1,20 +1,33 @@
-<?php
-
-if (!defined('ABSPATH')) {
-    exit; // Exit if accessed directly
-}
-        register_setting('hubspot_wc_settings', 'hubspot_connected');
-        register_setting('hubspot_wc_settings', 'hubspot_client_id');
-        register_setting('hubspot_wc_settings', 'hubspot_client_secret');
-        register_setting('hubspot_wc_settings', 'hubspot_pipeline_id');
-class HubSpot_WC_Settings {
-
-    public static function init() {
-        add_action('admin_menu', [__CLASS__, 'register_menu']);
-        add_action('admin_init', [__CLASS__, 'register_settings']);
-        add_action('wp_ajax_hubspot_check_connection', [__CLASS__, 'hubspot_check_connection']);
-        add_action('admin_init', [__CLASS__, 'maybe_refresh_cache_on_save']);
-        add_action('admin_post_hubspot_refresh_pipelines', [__CLASS__, 'handle_refresh_pipelines']);
+        add_menu_page(
+            __( 'HubSpot Settings', 'hub-woo-sync' ),
+            __( 'HubSpot', 'hub-woo-sync' ),
+            'manage_options',
+            'hubspot-woocommerce-sync',
+            [__CLASS__, 'render_settings_page'],
+            'dashicons-admin-generic',
+            56
+        <div class="wrap">
+            <h1><?php esc_html_e( 'HubSpot WooCommerce Sync', 'hub-woo-sync' ); ?></h1>
+            <h2 class="nav-tab-wrapper">
+                <a href="?page=hubspot-woocommerce-sync&tab=authentication" class="nav-tab <?php echo self::get_active_tab('authentication'); ?>"><?php esc_html_e( 'HubSpot Setup', 'hub-woo-sync' ); ?></a>
+                <a href="?page=hubspot-woocommerce-sync&tab=woocommerce" class="nav-tab <?php echo self::get_active_tab('woocommerce'); ?>"><?php esc_html_e( 'Pipelines', 'hub-woo-sync' ); ?></a>
+            </h2>
+        <h3><?php esc_html_e( 'HubSpot Authentication & Setup', 'hub-woo-sync' ); ?></h3>
+        <p><?php esc_html_e( 'Status', 'hub-woo-sync' ); ?>: <span id="hubspot-connection-status" style="color: red;"><?php esc_html_e( 'Checking...', 'hub-woo-sync' ); ?></span></p>
+        <div id="hubspot-account-info">
+            <p><strong><?php esc_html_e( 'HubSpot Account Details:', 'hub-woo-sync' ); ?></strong></p>
+            <ul>
+                <li><strong><?php esc_html_e( 'Portal ID:', 'hub-woo-sync' ); ?></strong> <span id="portal-id"><?php esc_html_e( 'Fetching...', 'hub-woo-sync' ); ?></span></li>
+                <li><strong><?php esc_html_e( 'Account Type:', 'hub-woo-sync' ); ?></strong> <span id="account-type"><?php esc_html_e( 'Fetching...', 'hub-woo-sync' ); ?></span></li>
+                <li><strong><?php esc_html_e( 'Time Zone:', 'hub-woo-sync' ); ?></strong> <span id="time-zone"><?php esc_html_e( 'Fetching...', 'hub-woo-sync' ); ?></span></li>
+                <li><strong><?php esc_html_e( 'Company Currency:', 'hub-woo-sync' ); ?></strong> <span id="company-currency"><?php esc_html_e( 'Fetching...', 'hub-woo-sync' ); ?></span></li>
+                <li><strong><?php esc_html_e( 'Data Hosting Location:', 'hub-woo-sync' ); ?></strong> <span id="data-hosting"><?php esc_html_e( 'Fetching...', 'hub-woo-sync' ); ?></span></li>
+                <li><strong><?php esc_html_e( 'Access Token:', 'hub-woo-sync' ); ?></strong> <span id="access-token"><?php esc_html_e( 'Fetching...', 'hub-woo-sync' ); ?></span></li>
+            </ul>
+        </div>
+        <a href="<?php echo esc_url($auth_url); ?>" class="button-primary" id="hubspot-auth-button">
+            <?php esc_html_e( 'Connect HubSpot', 'hub-woo-sync' ); ?>
+        </a>
     }
 
     /**
@@ -153,15 +166,23 @@ class HubSpot_WC_Settings {
                             $('#access-token').text(accountInfo["Access Token (truncated)"]);
                         } else {
                             $('#hubspot-connection-status').html('<span style="color: red;">Not Connected</span>');
-                            $('#hubspot-account-info ul').html('<li>No account linked</li>');
-                        }
-                    } catch (error) {
-                        console.error("❌ Error parsing response: ", response);
-                        $('#hubspot-connection-status').html('<span style="color: red;">Error Checking Connection</span>');
-                    }
-                }).fail(function(jqXHR, textStatus, errorThrown) {
-                    console.error("❌ AJAX Request Failed:", textStatus, errorThrown);
-                    $('#hubspot-connection-status').html('<span style="color: red;">AJAX Error</span>');
+                            $('#hubspot-account-info ul').html('<li>No account linked</li>');        <h3><?php esc_html_e( 'Hubspot Pipelines', 'hub-woo-sync' ); ?></h3>
+                <th><label for="hubspot_pipeline_sync_enabled"><?php esc_html_e( 'Enable Pipeline Sync', 'hub-woo-sync' ); ?></label></th>
+                    <span><?php esc_html_e( 'Enable automatic syncing of WooCommerce orders to HubSpot pipeline stages', 'hub-woo-sync' ); ?></span>
+                <th><label for="hubspot_pipeline_online"><?php esc_html_e( 'Online Orders Pipeline', 'hub-woo-sync' ); ?></label></th>
+                    <p><?php esc_html_e( 'Pipeline for customer-initiated online orders.', 'hub-woo-sync' ); ?></p>
+                <th><label for="hubspot_pipeline_manual"><?php esc_html_e( 'Manual Orders Pipeline', 'hub-woo-sync' ); ?></label></th>
+                    <p><?php esc_html_e( 'Pipeline for admin-created manual orders (e.g., after a customer enquiry).', 'hub-woo-sync' ); ?></p>
+                                <option value=""><?php esc_html_e( '— Select Stage —', 'hub-woo-sync' ); ?></option>
+        <h4><?php esc_html_e( 'Quote & Invoice Stage Mapping', 'hub-woo-sync' ); ?></h4>
+        $quote_invoice_stage_fields = [
+            'hubspot_stage_quote_sent'     => __( 'Quote Sent Stage', 'hub-woo-sync' ),
+            'hubspot_stage_quote_accepted' => __( 'Quote Accepted Stage', 'hub-woo-sync' ),
+            'hubspot_stage_invoice_sent'   => __( 'Invoice Sent Stage', 'hub-woo-sync' ),
+        ];
+            <h5><?php echo esc_html( ucfirst( $type ) ); ?> <?php esc_html_e( 'Orders', 'hub-woo-sync' ); ?></h5>
+                                <option value=""><?php esc_html_e( '— Select Stage —', 'hub-woo-sync' ); ?></option>
+
                 });
             }
 

--- a/hubspot-woocommerce-sync.php
+++ b/hubspot-woocommerce-sync.php
@@ -20,6 +20,13 @@ if ( ! defined( 'HUBSPOT_WC_SYNC_PATH' ) ) {
     define( 'HUBSPOT_WC_SYNC_URL', plugin_dir_url( __FILE__ ) );
 }
 
+add_action(
+    'plugins_loaded',
+    static function () {
+        load_plugin_textdomain( 'hub-woo-sync', false, basename( dirname( __FILE__ ) ) . '/languages' );
+    }
+);
+
 // Define HubSpot OAuth constants from saved options
 if ( ! defined( 'HUBSPOT_CLIENT_ID' ) ) {
     define( 'HUBSPOT_CLIENT_ID', get_option( 'hubspot_client_id', '' ) );

--- a/manual-actions.php
+++ b/manual-actions.php
@@ -1,28 +1,32 @@
     if ( ! current_user_can( 'manage_woocommerce' ) ) {
-        wp_send_json_error( 'Unauthorized', 403 );
+        wp_send_json_error( __( 'Unauthorized', 'hub-woo-sync' ), 403 );
     }
     $dealstage_id = $deal['dealstage'] ?? '';
 
     if (!isset($_POST['security']) || !wp_verify_nonce($_POST['security'], 'send_invoice_email_nonce')) {
-        wp_send_json_error('Invalid security token.');
+        wp_send_json_error( __( 'Invalid security token.', 'hub-woo-sync' ) );
     }
     if ( ! current_user_can( 'manage_woocommerce' ) ) {
-        wp_send_json_error( 'Unauthorized', 403 );
+        wp_send_json_error( __( 'Unauthorized', 'hub-woo-sync' ), 403 );
     }
 function hubwoo_manual_sync_hubspot_order() {
     check_ajax_referer('manual_sync_hubspot_order_nonce', 'security');
     if ( ! current_user_can( 'manage_woocommerce' ) ) {
-        wp_send_json_error( 'Unauthorized', 403 );
+        wp_send_json_error( __( 'Unauthorized', 'hub-woo-sync' ), 403 );
     }
     if ( ! current_user_can( 'manage_woocommerce' ) ) {
-        wp_send_json_error( 'Unauthorized', 403 );
+        wp_send_json_error( __( 'Unauthorized', 'hub-woo-sync' ), 403 );
     }
 
-    $pipeline_label = $labels['pipelines'][$pipeline_id] ?? $pipeline_id;    $type = hubwoo_order_type($order);
+        wp_send_json_error( __( 'Invalid security token.', 'hub-woo-sync' ) );
+        wp_send_json_error( __( 'Invalid Order ID.', 'hub-woo-sync' ) );
+        wp_send_json_error( __( 'Customer email not found.', 'hub-woo-sync' ) );
+    wp_send_json_success( __( 'Invoice sent successfully.', 'hub-woo-sync' ) );
+    if (!$order) wp_send_json_error( __( 'Invalid Order ID.', 'hub-woo-sync' ) );
+    if (!$deal_id) wp_send_json_error( __( 'Order not linked to a HubSpot deal.', 'hub-woo-sync' ) );
+    if (!$deal) wp_send_json_error( __( 'Failed to fetch deal from HubSpot.', 'hub-woo-sync' ) );
+        wp_send_json_error( __( 'Unauthorized', 'hub-woo-sync' ), 403 );
 
-    $type = hubwoo_order_type($order);
-add_action('wp_ajax_send_invoice_email', 'hubwoo_send_invoice_email_ajax');
-add_action('wp_ajax_manual_sync_hubspot_order', 'hubwoo_manual_sync_hubspot_order');
 function hubwoo_manual_sync_hubspot_order() {
 function hubwoo_create_hubspot_deal_manual() {
 
@@ -103,13 +107,14 @@ function hubwoo_create_hubspot_deal_manual() {
 
     $dealstage_label = $labels['stages'][$dealstage_id] ?? $dealstage_id;
 
-    // 🔄 Clear existing line and shipping items
-function create_hubspot_deal_manual() {
-    check_ajax_referer('create_hubspot_deal_nonce', 'security');
-    if ( ! current_user_can( 'manage_woocommerce' ) ) {
-        wp_send_json_error( 'Unauthorized', 403 );
-    }
-    foreach ($order->get_items('shipping') as $id => $item) $order->remove_item($id);
+    // 🔄 Clear existing line and shipping items    wp_send_json_success( __( 'Order updated with latest HubSpot deal info.', 'hub-woo-sync' ) );
+    if (!$order) wp_send_json_error( __( 'Invalid Order ID.', 'hub-woo-sync' ) );
+        wp_send_json_error( __( 'Order already has a HubSpot deal.', 'hub-woo-sync' ) );
+        wp_send_json_error( __( 'No HubSpot access token available.', 'hub-woo-sync' ) );
+        wp_send_json_error( __( 'Contact creation failed.', 'hub-woo-sync' ) );
+        wp_send_json_error( __( 'Deal creation failed. Check hubspot-sync.log for details.', 'hub-woo-sync' ) );
+    wp_send_json_success( __( 'HubSpot deal created successfully.', 'hub-woo-sync' ) );
+
 add_action('wp_ajax_create_hubspot_deal_manual', 'hubwoo_create_hubspot_deal_manual');
 function hubwoo_create_hubspot_deal_manual() {
     // 📦 Billing

--- a/send-quote.php
+++ b/send-quote.php
@@ -1,11 +1,14 @@
     check_ajax_referer('send_quote_email_nonce', 'security');
     if ( ! current_user_can( 'manage_woocommerce' ) ) {
-        wp_send_json_error( 'Unauthorized', 403 );
+        wp_send_json_error( __( 'Unauthorized', 'hub-woo-sync' ), 403 );
     }
 
-
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+        wp_send_json_error( __( 'Unauthorized', 'hub-woo-sync' ), 403 );
+    if (!$order) wp_send_json_error( __( 'Invalid Order ID.', 'hub-woo-sync' ) );
+    if (!$email) wp_send_json_error( __( 'No customer email found.', 'hub-woo-sync' ) );
+    wp_send_json_success( __( 'Quote sent successfully.', 'hub-woo-sync' ) );
+    if (!$order) wp_send_json_error( __( 'Invalid Order ID.', 'hub-woo-sync' ) );
+    wp_send_json_success( __( 'Quote status reset.', 'hub-woo-sync' ) );
 }
 
 function get_order_quote_status_info($order) {    $accept_url = site_url('/?accept_quote=yes&order_id=' . $order_id);add_action('init', 'hubwoo_handle_quote_acceptance_placeholder');


### PR DESCRIPTION
## Summary
- load plugin textdomain for translations
- internationalize HubSpot settings page strings
- wrap table headings and messages on order management page
- localize AJAX responses and admin strings across actions
- add languages folder for future translations

## Testing
- `php -l hubspot-woocommerce-sync.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685cafea383c8326a9de10a84eb0c4b7