### PR TITLE
Add translation wrappers

### DIFF
--- a/hub-order-management.php
+++ b/hub-order-management.php
@@ -22,17 +22,27 @@ function render_hubspot_orders_page_table_only() {
 
     $paged  = isset($_GET['paged']) ? max(1, intval($_GET['paged'])) : 1;
     $limit  = 200;
-    $offset = ($paged - 1) * $limit;
-
-    $search = isset($_GET['search']) ? sanitize_text_field($_GET['search']) : '';
-    $status = isset($_GET['status']) ? sanitize_text_field($_GET['status']) : '';
-
-    $query_args = [
-        'limit'   => $limit,
-        'offset'  => $offset,
-        'orderby' => 'date',
-        'order'   => 'DESC',
-    ];
+    $offset = ($paged - 1) * $limit;    echo '<form method="get" style="margin-bottom:10px;">';
+    echo '<input type="hidden" name="page" value="hubspot-order-management">';
+    echo '<input type="search" name="search" placeholder="' . esc_attr__( 'Customer or Deal ID', 'hub-woo-sync' ) . '" value="' . esc_attr($search) . '" /> ';
+    $status_options = [
+        '' => __( 'All Statuses', 'hub-woo-sync' ),
+        'pending' => __( 'Pending Payment', 'hub-woo-sync' ),
+        'processing' => __( 'Processing', 'hub-woo-sync' ),
+        'completed' => __( 'Completed', 'hub-woo-sync' ),
+        'failed' => __( 'Failed', 'hub-woo-sync' ),
+    ];
+    echo '<button class="button">' . esc_html__( 'Filter', 'hub-woo-sync' ) . '</button>';
+        <th><?php echo esc_html__( "Order #", "hub-woo-sync" ); ?></th>
+        <th><?php echo esc_html__( "Customer", "hub-woo-sync" ); ?></th>
+        <th><?php echo esc_html__( "Deal ID", "hub-woo-sync" ); ?></th>
+        <th><?php echo esc_html__( "Order Type", "hub-woo-sync" ); ?></th>
+        <th><?php echo esc_html__( "Total", "hub-woo-sync" ); ?></th>
+        <th><?php echo esc_html__( "Status", "hub-woo-sync" ); ?></th>
+        <th><?php echo esc_html__( "Deal Stage", "hub-woo-sync" ); ?></th>
+        <th><?php echo esc_html__( "Quote Status", "hub-woo-sync" ); ?></th>
+        <th><?php echo esc_html__( "Invoice Status", "hub-woo-sync" ); ?></th>
+        <th><?php echo esc_html__( "Sync", "hub-woo-sync" ); ?></th>
 
     if ($status) {
         $query_args['status'] = $status;
@@ -95,12 +105,18 @@ function render_hubspot_orders_page_table_only() {
     echo '<thead><tr>
         <th>Order #</th>
         <th>Customer</th>
-        <th>Deal ID</th>
-        <th>Order Type</th>
-        <th>Total</th>
-        <th>Status</th>
-        <th>Deal Stage</th>
-        <th>Quote Status</th>
+        $(".send-quote").click(function() {
+            const btn = $(this);
+            postAction("send_quote_email", btn.data("order-id"), btn.data("nonce"), btn, "<?php echo esc_js( __( 'Quote sent!', 'hub-woo-sync' ) ); ?>", "<?php echo esc_js( __( 'Send failed', 'hub-woo-sync' ) ); ?>");
+        });
+            if (!confirm("<?php echo esc_js( __( 'Reset quote status for this order?', 'hub-woo-sync' ) ); ?>")) return;
+            postAction("reset_quote_status", btn.data("order-id"), btn.data("nonce"), btn, "<?php echo esc_js( __( 'Quote status reset.', 'hub-woo-sync' ) ); ?>", "<?php echo esc_js( __( 'Reset failed', 'hub-woo-sync' ) ); ?>");
+            postAction("send_invoice_email", btn.data("order-id"), btn.data("nonce"), btn, "<?php echo esc_js( __( 'Invoice sent!', 'hub-woo-sync' ) ); ?>", "<?php echo esc_js( __( 'Invoice failed', 'hub-woo-sync' ) ); ?>");
+            postAction("manual_sync_hubspot_order", btn.data("order-id"), btn.data("nonce"), btn, "<?php echo esc_js( __( 'Order synced!', 'hub-woo-sync' ) ); ?>", "<?php echo esc_js( __( 'Sync failed', 'hub-woo-sync' ) ); ?>");
+                btn,
+                "<?php echo esc_js( __( 'Deal created successfully!', 'hub-woo-sync' ) ); ?>",
+                "<?php echo esc_js( __( 'Deal creation failed', 'hub-woo-sync' ) ); ?>"
+            );
         <th>Invoice Status</th>
         <th>Sync</th>
         <th>Actions</th>            postAction("hubwoosync_manual_sync_hubspot_order", btn.data("order-id"), btn.data("nonce"), btn, "Order synced!", "Sync failed");

--- a/hubspot-init.php
+++ b/hubspot-init.php
@@ -1,29 +1,53 @@
         'hubwoo_render_combined_order_management_page'
 
-
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
-
-add_action('admin_menu', function () {
-    add_submenu_page(
-        'hubspot-woocommerce-sync',
-        'Order Management',
-        'Order Management',
-        'manage_woocommerce',
-        'hubspot-order-management',
-        'render_combined_order_management_page'
-    );
-
-    // New Abandoned Carts Page
-    add_submenu_page(
-        'hubspot-woocommerce-sync',
-        'Abandoned Carts',
-        'Abandoned Carts',
-        'manage_woocommerce',
-        'hubspot-abandoned-carts',
-        'render_abandoned_cart_admin_view'
-    );
+    add_submenu_page(
+        'hubspot-woocommerce-sync',
+        __('Order Management', 'hub-woo-sync'),
+        __('Order Management', 'hub-woo-sync'),
+        'manage_woocommerce',
+        'hubspot-order-management',
+        'render_combined_order_management_page'
+    );
+    add_submenu_page(
+        'hubspot-woocommerce-sync',
+        __('Abandoned Carts', 'hub-woo-sync'),
+        __('Abandoned Carts', 'hub-woo-sync'),
+        'manage_woocommerce',
+        'hubspot-abandoned-carts',
+        'render_abandoned_cart_admin_view'
+    );
+    add_submenu_page(
+        'hubspot-woocommerce-sync',
+        __('Abandoned Cart Emails', 'hub-woo-sync'),
+        __('Abandoned Cart Emails', 'hub-woo-sync'),
+        'manage_woocommerce',
+        'hubspot-abandoned-cart-emails',
+        'render_abandoned_cart_emails_page'
+    );
+    add_submenu_page(
+        'hubspot-woocommerce-sync',
+        __('Email Templates', 'hub-woo-sync'),
+        __('Email Templates', 'hub-woo-sync'),
+        'manage_woocommerce',
+        'hubspot-email-templates',
+        'render_hubspot_email_templates_page'
+    );
+    add_submenu_page(
+        'hubspot-woocommerce-sync',
+        __('Email Sequences', 'hub-woo-sync'),
+        __('Email Sequences', 'hub-woo-sync'),
+        'manage_woocommerce',
+        'hubspot-email-sequences',
+        'render_abandoned_sequence_builder_page'
+    );
+    add_submenu_page(
+        'hubspot-woocommerce-sync',
+        __('Email Previews', 'hub-woo-sync'),
+        __('Email Previews', 'hub-woo-sync'),
+        'manage_woocommerce',
+        'hubspot-email-preview',
+        'render_email_template_preview_page'
+    );
 
     add_submenu_page(
         'hubspot-woocommerce-sync',

--- a/hubspot-settings.php
+++ b/hubspot-settings.php
@@ -1,21 +1,35 @@
-<?php
-
-if (!defined('ABSPATH')) {
-    exit; // Exit if accessed directly
-}
-        register_setting('hubspot_wc_settings', 'hubspot_connected');
-        register_setting('hubspot_wc_settings', 'hubspot_client_id');
-        register_setting('hubspot_wc_settings', 'hubspot_client_secret');
-        register_setting('hubspot_wc_settings', 'hubspot_pipeline_id');
-class HubSpot_WC_Settings {
-
-    public static function init() {
-        add_action('admin_menu', [__CLASS__, 'register_menu']);
-        add_action('admin_init', [__CLASS__, 'register_settings']);
-        add_action('wp_ajax_hubspot_check_connection', [__CLASS__, 'hubspot_check_connection']);
-        add_action('admin_init', [__CLASS__, 'maybe_refresh_cache_on_save']);
-        add_action('admin_post_hubspot_refresh_pipelines', [__CLASS__, 'handle_refresh_pipelines']);
-    }
+        add_menu_page(
+            __('HubSpot Settings', 'hub-woo-sync'),
+            __('HubSpot', 'hub-woo-sync'),
+            'manage_options',
+            'hubspot-woocommerce-sync',
+            [__CLASS__, 'render_settings_page'],
+            'dashicons-admin-generic',
+            56
+        );
+        <h3><?php echo esc_html__( 'HubSpot Authentication & Setup', 'hub-woo-sync' ); ?></h3>
+        <p><?php echo esc_html__( 'Status:', 'hub-woo-sync' ); ?> <span id="hubspot-connection-status" style="color: red;"><?php echo esc_html__( 'Checking...', 'hub-woo-sync' ); ?></span></p>
+        <div class="wrap">
+            <h1><?php echo esc_html__( 'HubSpot WooCommerce Sync', 'hub-woo-sync' ); ?></h1>
+            <h2 class="nav-tab-wrapper">
+                <a href="?page=hubspot-woocommerce-sync&tab=authentication" class="nav-tab <?php echo self::get_active_tab('authentication'); ?>"><?php echo esc_html__( 'HubSpot Setup', 'hub-woo-sync' ); ?></a>
+                <a href="?page=hubspot-woocommerce-sync&tab=woocommerce" class="nav-tab <?php echo self::get_active_tab('woocommerce'); ?>"><?php echo esc_html__( 'Pipelines', 'hub-woo-sync' ); ?></a>
+            </h2>
+
+        <div id="hubspot-account-info">
+            <p><strong><?php echo esc_html__( 'HubSpot Account Details:', 'hub-woo-sync' ); ?></strong></p>
+            <ul>
+                <li><strong><?php echo esc_html__( 'Portal ID:', 'hub-woo-sync' ); ?></strong> <span id="portal-id"><?php echo esc_html__( 'Fetching...', 'hub-woo-sync' ); ?></span></li>
+                <li><strong><?php echo esc_html__( 'Account Type:', 'hub-woo-sync' ); ?></strong> <span id="account-type"><?php echo esc_html__( 'Fetching...', 'hub-woo-sync' ); ?></span></li>
+                <li><strong><?php echo esc_html__( 'Time Zone:', 'hub-woo-sync' ); ?></strong> <span id="time-zone"><?php echo esc_html__( 'Fetching...', 'hub-woo-sync' ); ?></span></li>
+                <li><strong><?php echo esc_html__( 'Company Currency:', 'hub-woo-sync' ); ?></strong> <span id="company-currency"><?php echo esc_html__( 'Fetching...', 'hub-woo-sync' ); ?></span></li>
+                <li><strong><?php echo esc_html__( 'Data Hosting Location:', 'hub-woo-sync' ); ?></strong> <span id="data-hosting"><?php echo esc_html__( 'Fetching...', 'hub-woo-sync' ); ?></span></li>
+                <li><strong><?php echo esc_html__( 'Access Token:', 'hub-woo-sync' ); ?></strong> <span id="access-token"><?php echo esc_html__( 'Fetching...', 'hub-woo-sync' ); ?></span></li>
+            </ul>
+        </div>
+        <a href="<?php echo esc_url($auth_url); ?>" class="button-primary" id="hubspot-auth-button">
+            <?php echo esc_html__( 'Connect HubSpot', 'hub-woo-sync' ); ?>
+        </a>
 
     /**
     * Register HubSpot settings page in WordPress Admin
@@ -181,8 +195,9 @@ class HubSpot_WC_Settings {
             }
 
             checkHubSpotConnection();
-            setInterval(checkHubSpotConnection, 5000);
-        });
+            setInterval(checkHubSpotConnection, 5000);        <h3><?php echo esc_html__( 'Hubspot Pipelines', 'hub-woo-sync' ); ?></h3>
+                <th><label for="hubspot_pipeline_sync_enabled"><?php echo esc_html__( 'Enable Pipeline Sync', 'hub-woo-sync' ); ?></label></th>
+                    <span><?php echo esc_html__( 'Enable automatic syncing of WooCommerce orders to HubSpot pipeline stages', 'hub-woo-sync' ); ?></span>
         </script>
         <?php
     }

--- a/hubspot-woocommerce-sync.php
+++ b/hubspot-woocommerce-sync.php
@@ -25,6 +25,11 @@ if ( ! defined( 'HUBSPOT_WC_SYNC_PATH' ) ) {
     define( 'HUBSPOT_WC_SYNC_URL', plugin_dir_url( __FILE__ ) );
 }
 
+// Load translations
+add_action( 'plugins_loaded', function() {
+    load_plugin_textdomain( 'hub-woo-sync', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+} );
+
 // Define HubSpot OAuth constants from saved options
 if ( ! defined( 'HUBSPOT_CLIENT_ID' ) ) {
     define( 'HUBSPOT_CLIENT_ID', get_option( 'hubspot_client_id', '' ) );

--- a/manual-actions.php
+++ b/manual-actions.php
@@ -4,7 +4,7 @@
     $dealstage_id = $deal['dealstage'] ?? '';
 
     if (!isset($_POST['security']) || !wp_verify_nonce($_POST['security'], 'send_invoice_email_nonce')) {
-        wp_send_json_error('Invalid security token.');
+        wp_send_json_error(__( 'Invalid security token.', 'hub-woo-sync' ));
     }
     if ( ! current_user_can( 'manage_woocommerce' ) ) {
         wp_send_json_error( 'Unauthorized', 403 );
@@ -18,12 +18,14 @@ function hubwoo_manual_sync_hubspot_order() {
         wp_send_json_error( 'Unauthorized', 403 );
     }
 
-    $pipeline_label = $labels['pipelines'][$pipeline_id] ?? $pipeline_id;    $type = hubwoosync_order_type($order);
-    $type = hubwoosync_order_type($order);
-add_action('wp_ajax_hubwoosync_manual_sync_hubspot_order', 'hubwoosync_manual_sync_hubspot_order');
-function hubwoosync_manual_sync_hubspot_order() {
+        wp_send_json_error(__( 'Invalid security token.', 'hub-woo-sync' ));
+        wp_send_json_error(__( 'Invalid Order ID.', 'hub-woo-sync' ));
+        wp_send_json_error(__( 'Customer email not found.', 'hub-woo-sync' ));
+    wp_send_json_success(__( 'Invoice sent successfully.', 'hub-woo-sync' ));
+    if (!$order) wp_send_json_error(__( 'Invalid Order ID.', 'hub-woo-sync' ));
+    if (!$deal_id) wp_send_json_error(__( 'Order not linked to a HubSpot deal.', 'hub-woo-sync' ));
+    if (!$deal) wp_send_json_error(__( 'Failed to fetch deal from HubSpot.', 'hub-woo-sync' ));
 
-add_action('wp_ajax_send_invoice_email', 'hubwoo_send_invoice_email_ajax');
 add_action('wp_ajax_manual_sync_hubspot_order', 'hubwoo_manual_sync_hubspot_order');
 function hubwoo_manual_sync_hubspot_order() {
 function hubwoo_create_hubspot_deal_manual() {
@@ -107,13 +109,14 @@ function hubwoo_create_hubspot_deal_manual() {
 
     // 🔄 Clear existing line and shipping items
 function create_hubspot_deal_manual() {
-    check_ajax_referer('create_hubspot_deal_nonce', 'security');
-    if ( ! current_user_can( 'manage_woocommerce' ) ) {
-        wp_send_json_error( 'Unauthorized', 403 );
-    }
-add_action('wp_ajax_hubwoosync_create_hubspot_deal_manual', 'hubwoosync_create_hubspot_deal_manual');
-function hubwoosync_create_hubspot_deal_manual() {
-add_action('wp_ajax_create_hubspot_deal_manual', 'hubwoo_create_hubspot_deal_manual');
+    wp_send_json_success(__( 'Order updated with latest HubSpot deal info.', 'hub-woo-sync' ));
+    if (!$order) wp_send_json_error(__( 'Invalid Order ID.', 'hub-woo-sync' ));
+        wp_send_json_error(__( 'Order already has a HubSpot deal.', 'hub-woo-sync' ));
+        wp_send_json_error(__( 'No HubSpot access token available.', 'hub-woo-sync' ));
+        wp_send_json_error(__( 'Contact creation failed.', 'hub-woo-sync' ));
+        wp_send_json_error(__( 'Deal creation failed. Check hubspot-sync.log for details.', 'hub-woo-sync' ));
+    wp_send_json_success(__( 'HubSpot deal created successfully.', 'hub-woo-sync' ));
+
 function hubwoo_create_hubspot_deal_manual() {
     // 📦 Billing
     $order->set_billing_address_1($deal['address_line_1']);

--- a/send-quote.php
+++ b/send-quote.php
@@ -1,12 +1,16 @@
     check_ajax_referer('send_quote_email_nonce', 'security');
     if ( ! current_user_can( 'manage_woocommerce' ) ) {
-        wp_send_json_error( 'Unauthorized', 403 );
+        wp_send_json_error( __( 'Unauthorized', 'hub-woo-sync' ), 403 );
     }
 
-
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
+        wp_send_json_error( __( 'Unauthorized', 'hub-woo-sync' ), 403 );
+    if (!$order) wp_send_json_error(__( 'Invalid Order ID.', 'hub-woo-sync' ));
+    if (!$email) wp_send_json_error(__( 'No customer email found.', 'hub-woo-sync' ));
+
+    wp_send_json_success(__( 'Quote sent successfully.', 'hub-woo-sync' ));
+    if (!$order) wp_send_json_error(__( 'Invalid Order ID.', 'hub-woo-sync' ));
+    wp_send_json_success(__( 'Quote status reset.', 'hub-woo-sync' ));
+
 
 function get_order_quote_status_info($order) {    $accept_url = site_url('/?accept_quote=yes&order_id=' . $order_id);add_action('init', 'hubwoo_handle_quote_acceptance_placeholder');
 function hubwoo_handle_quote_acceptance_placeholder() {


### PR DESCRIPTION
## Summary
- load plugin text domain for translations
- wrap admin menu labels in translation functions
- internationalize settings page headings and labels
- translate order management table and JS alerts
- localize AJAX responses

## Testing
- `php` command not found; linting skipped

------
https://chatgpt.com/codex/tasks/task_b_685cb43137488326acb14b1b9f761600