### PR TITLE
Fix sync logic and remove duplicate hooks

### DIFF
--- a/manual-actions.php
+++ b/manual-actions.php
@@ -1,58 +1,36 @@
-    if ( ! current_user_can( 'manage_woocommerce' ) ) {
-        wp_send_json_error( 'Unauthorized', 403 );
-    }
-    $dealstage_id = $deal['dealstage'] ?? '';
-
-    if (!isset($_POST['security']) || !wp_verify_nonce($_POST['security'], 'send_invoice_email_nonce')) {
-        wp_send_json_error(__( 'Invalid security token.', 'hub-woo-sync' ));
-    }
-    if ( ! current_user_can( 'manage_woocommerce' ) ) {
-        wp_send_json_error( 'Unauthorized', 403 );
-    }
-
-    check_ajax_referer('manual_sync_hubspot_order_nonce', 'security');
-    if ( ! current_user_can( 'manage_woocommerce' ) ) {
-        wp_send_json_error( 'Unauthorized', 403 );
-    }
-    if ( ! current_user_can( 'manage_woocommerce' ) ) {
-        wp_send_json_error( 'Unauthorized', 403 );
-    }
-
-    $type = hubwoosync_order_type($order);
-
-        wp_send_json_error(__( 'Customer email not found.', 'hub-woo-sync' ));
-    wp_send_json_success(__( 'Invoice sent successfully.', 'hub-woo-sync' ));
-    if (!$order) wp_send_json_error(__( 'Invalid Order ID.', 'hub-woo-sync' ));
-    if (!$deal_id) wp_send_json_error(__( 'Order not linked to a HubSpot deal.', 'hub-woo-sync' ));
-    if (!$deal) wp_send_json_error(__( 'Failed to fetch deal from HubSpot.', 'hub-woo-sync' ));
-
-add_action('wp_ajax_manual_sync_hubspot_order', 'hubwoo_manual_sync_hubspot_order');
-function hubwoo_manual_sync_hubspot_order() {
-function hubwoo_create_hubspot_deal_manual() {
-
-    $pipeline_label = $labels['pipelines'][$pipeline_id] ?? $pipeline_id;    $type = order_type($order);
-    $invoice_stage_id = $type === 'manual'
-        ? get_option('hubspot_stage_invoice_sent_manual')
-        : get_option('hubspot_stage_invoice_sent_online');
-
+<?php
+/**
+ * Manual Helper Functions
+ *
+ * @package Steelmark
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+function hubwoosync_send_invoice_email_ajax() {
+    if (!$email) {
+        wp_send_json_error('Customer email not found.');
+    hubwoosync_log_email_in_hubspot($order_id, "invoice");
     if ($invoice_stage_id) {
-        update_hubspot_deal_stage($order_id, $invoice_stage_id);
+        hubwoosync_update_hubspot_deal_stage($order_id, $invoice_stage_id);
     }
+add_action('wp_ajax_send_invoice_email', 'hubwoosync_send_invoice_email_ajax');
+add_action('wp_ajax_hubwoosync_manual_sync_hubspot_order', 'hubwoosync_manual_sync_hubspot_order');
+function hubwoosync_manual_sync_hubspot_order() {
+    check_ajax_referer('hubwoosync_manual_sync_hubspot_order_nonce', 'security');
+    $dealstage_id = $deal['dealstage'] ?? '';
+    $pipeline_label = $labels['pipelines'][$pipeline_id] ?? $pipeline_id;
+    foreach ($order->get_items() as $id => $item) $order->remove_item($id);
+    foreach ($order->get_items('shipping') as $id => $item) $order->remove_item($id);
+
+    if (!empty($deal['contacts'])) {
+        if ($contact) {
+            $order->set_billing_first_name($contact['firstname'] ?? '');
+        if ($company) {
 
-    log_email_in_hubspot($order_id, 'invoice');
-
-    // Validate request
-    if (!isset($_POST['security']) || !wp_verify_nonce($_POST['security'], 'send_invoice_email_nonce')) {
-        wp_send_json_error('Invalid security token.');
-    }
-
-    $order_id = isset($_POST['order_id']) ? absint($_POST['order_id']) : 0;
-    $order = wc_get_order($order_id);
-
-    if (!$order) {
-        wp_send_json_error('Invalid Order ID.');
-    }
-
     $email = $order->get_billing_email();
 
     }
@@ -110,8 +88,9 @@ function hubwoo_create_hubspot_deal_manual() {
 function create_hubspot_deal_manual() {
     wp_send_json_success(__( 'Order updated with latest HubSpot deal info.', 'hub-woo-sync' ));
     if (!$order) wp_send_json_error(__( 'Invalid Order ID.', 'hub-woo-sync' ));
-        wp_send_json_error(__( 'Order already has a HubSpot deal.', 'hub-woo-sync' ));
-        wp_send_json_error(__( 'No HubSpot access token available.', 'hub-woo-sync' ));
+        wp_send_json_error(__( 'Order already has a HubSpot deal.', 'hub-woo-sync' ));add_action('wp_ajax_hubwoosync_create_hubspot_deal_manual', 'hubwoosync_create_hubspot_deal_manual');
+function hubwoosync_create_hubspot_deal_manual() {
+
         wp_send_json_error(__( 'Contact creation failed.', 'hub-woo-sync' ));
         wp_send_json_error(__( 'Deal creation failed. Check hubspot-sync.log for details.', 'hub-woo-sync' ));
     wp_send_json_success(__( 'HubSpot deal created successfully.', 'hub-woo-sync' ));

--- a/online-order-sync.php
+++ b/online-order-sync.php
@@ -1,148 +1,155 @@
-add_action('woocommerce_new_order', 'hubwoosync_set_order_type_for_online_orders', 20, 2);
-add_action('woocommerce_new_order', 'hubwoosync_set_order_type_for_online_orders', 20, 2);
-function hubwoosync_set_order_type_for_online_orders($order_id, $order) {
+<?php
+/**
+ * Auto-sync WooCommerce Online Orders to HubSpot with Logging
+ */
 
-add_action('woocommerce_new_order', 'hubwoosync_set_order_type_for_online_orders', 20, 2);
-add_action('woocommerce_payment_complete', 'hubwoosync_auto_sync_online_order', 10, 1);
-add_action('woocommerce_new_order', 'hubwoosync_set_order_type_for_online_orders', 20, 2);
-add_action('woocommerce_payment_complete', 'hubwoosync_auto_sync_online_order', 10, 1);
-function hubwoosync_set_order_type_for_online_orders($order_id, $order) {
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
-if (!defined('ABSPATH')) exit;
-
-/*
-*
-    // Detect if order was created from admin, REST API, or CLI
-    if (is_admin() || defined('REST_REQUEST') || (php_sapi_name() === 'cli')) {
-        if (strtolower($existing_order_type) !== 'manual') {
-            $order->update_meta_data('order_type', 'manual');
-            $order->save_meta_data();
-        }
-        return;
+/**
+ * Mark orders created via the frontend as online and admin orders as manual.
+ */
+add_action( 'woocommerce_new_order', 'hubwoosync_set_order_type_for_online_orders', 20, 2 );
+function hubwoosync_set_order_type_for_online_orders( $order_id, $order ) {
+    if ( ! is_a( $order, 'WC_Order' ) ) {
+        $order = wc_get_order( $order_id );
     }
 
-    // Skip if already marked as 'manual'
-    if (strtolower($existing_order_type) === 'manual') {
-        return;
+    $existing = $order->get_meta( 'order_type' );
+
+    // Admin/REST/CLI orders are treated as manual
+    if ( is_admin() || defined( 'REST_REQUEST' ) || php_sapi_name() === 'cli' ) {
+        if ( strtolower( $existing ) !== 'manual' ) {
+            $order->update_meta_data( 'order_type', 'manual' );
+    // Skip if already marked manual
+    if ( strtolower( $existing ) === 'manual' ) {
+
+    $customer_id = $order->get_customer_id();
+    $is_guest    = $order->get_user_id() === 0;
+    if ( $is_guest || $customer_id > 0 ) {
+        $order->update_meta_data( 'order_type', 'online' );
+        $order->save_meta_data();
+    }
+}
+
+add_filter( 'woocommerce_orders_table_meta_keys', function ( $keys ) {
+    $keys[] = 'hubspot_deal_id';
+    $keys[] = 'hubspot_pipeline';
+    $keys[] = 'hubspot_dealstage';
+    $keys[] = 'hubspot_pipeline_id';
+    $keys[] = 'hubspot_dealstage_id';
+    $keys[] = 'invoice_status';
+    $keys[] = 'quote_status';
+    $keys[] = 'quote_last_sent';
+    $keys[] = 'order_type';
+    return $keys;
+} );
+
+/**
+ * Entry point for HubSpot sync after WooCommerce order payment completion.
+ */
+add_action( 'woocommerce_payment_complete', 'hubwoosync_auto_sync_online_order', 10, 1 );
+function hubwoosync_auto_sync_online_order( $order_id ) {
+    $order = wc_get_order( $order_id );
+    if ( ! $order || is_order_manual( $order ) ) {
     }
 
-add_action('woocommerce_new_order', 'set_order_type_for_online_orders', 20, 2);
-    // Detect if order was created from admin, CLI, or API (e.g. Zapier)
-    if (is_admin() || defined('REST_REQUEST') || (php_sapi_name() === 'cli')) {
-        if (strtolower($existing_order_type) !== 'manual') {
-            $order->update_meta_data('order_type', 'manual');
-            $order->save_meta_data();
-        }
-        return;
+    if ( ! $order->get_meta( 'order_type' ) ) {
+        $order->update_meta_data( 'order_type', 'online' );
+        $order->save_meta_data();
     }
-    if (!is_a($order, 'WC_Order')) {
-        $order = wc_get_order($order_id);
-    }
-
-    $existing_order_type = $order->get_meta('order_type');
-
-    if (is_admin() || strtolower($existing_order_type) === 'manual') {
-        return;
-    }
- * Entry point for HubSpot sync after order payment completion
-// Trigger deal creation after successful payment
-add_action('woocommerce_payment_complete', 'hubspot_auto_sync_online_order', 10, 1);
-    $order->update_meta_data('order_type', 'online');
-    $order->save_meta_data();
-}
-*/
-
-add_action('woocommerce_new_order', 'set_order_type_for_online_orders', 20, 2);
-// Trigger deal creation after successful payment
-add_action('woocommerce_payment_complete', 'hubspot_auto_sync_online_order', 10, 1);
 
-function set_order_type_for_online_orders($order_id, $order) {
-    if (!is_a($order, 'WC_Order')) {
-        $order = wc_get_order($order_id);
-    }
-
-    $existing_order_type = $order->get_meta('order_type');
-
-    // Skip if already marked as 'manual'
+    if ( $order->get_meta( 'hubspot_deal_id' ) ) {
+
     $access_token = manage_hubspot_access_token();
-    if (is_wp_error($access_token) || !$access_token) {
-        $error_message = is_wp_error($access_token) ? $access_token->get_error_message() : 'Access token not available';
-        $order->add_order_note('❌ HubSpot sync failed: ' . $error_message);
-        return;
-    }
-add_action('woocommerce_checkout_order_processed', 'hubwoosync_auto_sync_online_order', 20, 1);
-function hubwoosync_auto_sync_online_order($order_id) {
-        $error_message = is_wp_error($contact_id) ? $contact_id->get_error_message() : 'Unable to create or fetch contact';
-        $order->add_order_note('❌ HubSpot sync failed: ' . $error_message);
-        return;
-    }
-    $pipeline_id = get_option('hubspot_pipeline_online');
-    if (!$pipeline_id) {
-        $order->add_order_note('❌ HubSpot sync failed: HubSpot pipeline not configured.');
-        return;
-    }
-    $deal_id = hubspot_create_deal_from_order($order, $pipeline_id, $deal_stage, $contact_id, $access_token);
-    if (is_wp_error($deal_id) || !$deal_id) {
-        $error_message = is_wp_error($deal_id) ? $deal_id->get_error_message() : 'Deal creation failed';
-        $order->add_order_note('❌ HubSpot sync failed: ' . $error_message);
-        return;
-    }
-    // Detect if order was created from admin, CLI, or API (e.g. Zapier)
-    if (is_admin() || defined('REST_REQUEST') || (php_sapi_name() === 'cli')) {
-        return;
-    }
-
-    // Only continue if customer ID is set (logged-in customer) or user is guest
-    $customer_id = $order->get_customer_id();
-    // Create the deal
-    $deal_id = hubspot_create_deal_from_order($order, $pipeline_id, $deal_stage, $contact_id, $access_token);
-    if (!$deal_id) {
-        $order->add_order_note('❌ HubSpot deal creation failed.');
-        return;
+    if ( ! $access_token ) {
+
+    $email      = $order->get_billing_email();
+    $contact_id = hubspot_get_or_create_contact( $order, $email, $access_token );
+    if ( ! $contact_id ) {
+
+    $company_id  = null;
+    $company_name = $order->get_billing_company();
+    if ( ! empty( $company_name ) ) {
+        $company_id = hubspot_get_or_create_company( $company_name, $access_token );
     }
 
-    // If it's either a guest or a customer (i.e. not system generated), set type to 'online'
-    if ($is_guest || $customer_id > 0) {
-        $order->update_meta_data('order_type', 'online');
-        $order->save_meta_data();
-    }
-}
-
-
-add_filter('woocommerce_orders_table_meta_keys', function($keys) {
-    $keys[] = 'hubspot_deal_id';
-    $keys[] = 'hubspot_pipeline';
-    $keys[] = 'hubspot_dealstage';
-    $keys[] = 'hubspot_pipeline_id';
-    $keys[] = 'hubspot_dealstage_id';
-    $keys[] = 'invoice_status';
-    $keys[] = 'quote_status';
-    $keys[] = 'quote_last_sent';
-    $keys[] = 'order_type';
-    return $keys;
-});
-
-/**
- * Entry point for HubSpot sync after WooCommerce order
- */
-
-add_action('woocommerce_checkout_order_processed', 'hubspot_auto_sync_online_order', 20, 1);
-
-function hubspot_auto_sync_online_order($order_id) {
-    $order = wc_get_order($order_id);
-    if (!$order || is_order_manual($order)) return;
-
-    // Ensure order_type is tagged
-    if (!$order->get_meta('order_type')) {
-        $order->update_meta_data('order_type', 'online');
-        $order->save_meta_data();
-    }
-
-    // Prevent duplicate deal creation
-    if ($order->get_meta('hubspot_deal_id')) return;
-
-    $access_token = manage_hubspot_access_token();
-    if (!$access_token) return;
+    $pipeline_id = get_option( 'hubspot_pipeline_online' );
+    if ( ! $pipeline_id ) {
+
+    $status     = $order->get_status();
+    $status_key = "online_wc-{$status}";
+    $mapping    = get_option( 'hubspot_status_stage_mapping', [] );
+    $deal_stage = $mapping[ $status_key ] ?? '';
+    if ( ! $deal_stage ) {
+        $deal_stage = hubspot_get_first_stage_of_pipeline( $pipeline_id, $access_token );
+    }
+
+    $deal_id = hubspot_create_deal_from_order( $order, $pipeline_id, $deal_stage, $contact_id, $access_token );
+    if ( ! $deal_id ) {
+
+    hubspot_associate_objects( 'deal', $deal_id, 'contact', $contact_id, $access_token );
+    if ( $company_id ) {
+        hubspot_associate_objects( 'deal', $deal_id, 'company', $company_id, $access_token );
+    }
+
+    hubwoosync_add_line_items_to_deal( $order, $deal_id, $access_token );
+
+    $labels         = get_hubspot_pipeline_and_stage_labels();
+    $pipeline_label = $labels['pipelines'][ $pipeline_id ] ?? $pipeline_id;
+    $stage_label    = $labels['stages'][ $deal_stage ] ?? $deal_stage;
+
+    $order->update_meta_data( 'hubspot_deal_id', $deal_id );
+    $order->update_meta_data( 'hubspot_pipeline_id', $pipeline_id );
+    $order->update_meta_data( 'hubspot_pipeline', $pipeline_label );
+    $order->update_meta_data( 'hubspot_dealstage_id', $deal_stage );
+    $order->update_meta_data( 'hubspot_dealstage', $stage_label );
+    $order->add_order_note( "✔️ HubSpot deal created. Deal ID: {$deal_id}" );
+    $order->save();
+}
+
+/**
+ * Add line items with logging.
+ */
+function hubwoosync_add_line_items_to_deal( $order, $deal_id, $access_token ) {
+    foreach ( $order->get_items() as $item ) {
+        $name     = $item->get_name();
+        $qty      = $item->get_quantity();
+        $subtotal = $item->get_subtotal();
+        $price    = $qty > 0 ? $subtotal / $qty : 0;
+        $sku      = $item->get_product() ? $item->get_product()->get_sku() : '';
+        $gst      = round( $item->get_total_tax(), 2 );
+
+        $line_item_id = hubwoosync_create_line_item( $name, $price, $qty, $sku, $gst, $access_token );
+        if ( $line_item_id ) {
+            hubspot_associate_objects( 'deal', $deal_id, 'line_item', $line_item_id, $access_token );
+        }
+    }
+}
+
+function hubwoosync_create_line_item( $name, $price, $quantity, $sku, $gst, $access_token ) {
+    $payload = [
+        'properties' => [
+            'name'     => $name,
+            'price'    => round( $price, 2 ),
+            'quantity' => $quantity,
+            'sku'      => $sku,
+            'gst'      => $gst,
+        ],
+    ];
+
+    $response = wp_remote_post( 'https://api.hubapi.com/crm/v3/objects/line_items', [
+        'headers' => [
+            'Authorization' => "Bearer {$access_token}",
+            'Content-Type'  => 'application/json',
+        ],
+        'body'    => json_encode( $payload ),
+    ] );
+
+    $data = json_decode( wp_remote_retrieve_body( $response ), true );
+    return $data['id'] ?? null;
+}
 
     // Create or fetch HubSpot contact
     $email = $order->get_billing_email();


### PR DESCRIPTION
## Summary
- prevent early deal creation and undefined variable usage in online order flow
- rename and simplify quote/invoice handlers and remove duplicate hook
- ensure invoice stage update occurs when sending invoice

## Testing
- `php -l send-quote.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685cd50266008326ab874b66461d77aa