### PR TITLE
Fix packaging script error by defining plugin slug

### DIFF
--- a/hubspot-woocommerce-sync.php
+++ b/hubspot-woocommerce-sync.php
@@ -25,6 +25,11 @@ if ( ! defined( 'HUBSPOT_WC_SYNC_PATH' ) ) {
     define( 'HUBSPOT_WC_SYNC_URL', plugin_dir_url( __FILE__ ) );
 }
 
+// Declare the plugin slug for packaging scripts.
+if ( ! defined( 'WXL_PLUGIN_SLUG' ) ) {
+    define( 'WXL_PLUGIN_SLUG', 'hubspot-woocommerce-sync' );
+}
+
 // Load translations
 add_action( 'plugins_loaded', function() {
     load_plugin_textdomain( 'hubspot-woocommerce-sync', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );


### PR DESCRIPTION
## Summary
- declare `WXL_PLUGIN_SLUG` in the main plugin file

This constant is needed for `bin/package.sh` which checks that the plugin slug matches the packaging slug.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685dda6283948326b6970ce9bc065789