### PR TITLE
Fix slug detection in packaging script

### DIFF
--- a/bin/package.sh
+++ b/bin/package.sh
@@ -12,7 +12,7 @@ if [ ! -f "$PLUGIN_FILE" ]; then
 fi
 
 # Ensure the plugin's declared slug matches the packaging slug
-DECLARED_SLUG=$(grep -E "^\s*define\('WXL_PLUGIN_SLUG'" "$PLUGIN_FILE" | sed -E "s/.*'([^']+)'.*/\1/")
+DECLARED_SLUG=$(grep -E "^[[:space:]]*define\(\s*'WXL_PLUGIN_SLUG'" "$PLUGIN_FILE" | sed -E "s/.*'([^']+)'.*/\1/")
 if [ "$DECLARED_SLUG" != "$SLUG" ]; then
   echo "ERROR: WXL_PLUGIN_SLUG in $PLUGIN_FILE is '$DECLARED_SLUG' but expected '$SLUG'" >&2
   exit 1


### PR DESCRIPTION
## Summary
- handle spaces properly when reading WXL_PLUGIN_SLUG in `bin/package.sh`

## Testing
- `bash bin/package.sh` *(fails: exit code 141)*

------
https://chatgpt.com/codex/tasks/task_b_685de5902aa48326b488eeed37a4dd85