### PR TITLE
Fix manual actions association call

### DIFF
--- a/includes/manual-actions.php
+++ b/includes/manual-actions.php
@@ -186,7 +186,8 @@ function hubwoosync_create_hubspot_deal_manual() {
     $order->update_meta_data('order_type', 'manual');
     $order->save();
 
-    hubspot_associate_objects($deal_id, $contact_id, $order);
+    // Associate the new deal with the contact in HubSpot
+    hubspot_associate_objects('deal', $deal_id, 'contact', $contact_id, $token);
 
     $order->add_order_note("✅ Created HubSpot deal #{$deal_id} (Manual pipeline)");
 


### PR DESCRIPTION
## Summary
- call `hubspot_associate_objects()` with explicit object types
- keep token retrieval for association

## Testing
- `php -l includes/manual-actions.php`

------
https://chatgpt.com/codex/tasks/task_b_685e23cce91c832693746c2b62cc893d