### PR TITLE
Load credentials from variables.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ HubSpot WooCommerce Sync is a WordPress plugin that integrates WooCommerce with 
 ## Setup & Authentication
 
 1. **Go to WordPress Admin → HubSpot Sync**.
-2. Enter your HubSpot **Client ID** and **Client Secret** in the settings form.
+2. Ensure the plugin's `variables.php` file contains your HubSpot **Client ID** and **Client Secret**.
 3. Click the **Connect HubSpot** button and follow the authorization flow.
 4. Once authenticated, choose your **HubSpot pipeline** for WooCommerce orders.
 5. Enable **Automatic Deal Creation** to sync new orders.
@@ -131,7 +131,7 @@ creating an order in the admin, go to **HubSpot → Order Management** and click
 the **Create Deal** button to push the order to HubSpot.
 
 ### HubSpot App Credentials
-Your HubSpot app's **Client ID** and **Client Secret** are stored as plugin options. They can be updated anytime from the HubSpot Sync settings page.
+Your HubSpot app's **Client ID** and **Client Secret** are loaded from the `variables.php` file in the plugin directory.
 
 ## REST API Endpoints
 

--- a/hubspot-woocommerce-sync.php
+++ b/hubspot-woocommerce-sync.php
@@ -35,15 +35,18 @@ add_action('plugins_loaded', function () {
     load_plugin_textdomain('hubspot-woocommerce-sync', false, dirname(plugin_basename(__FILE__)) . '/languages');
 });
 
-// Define HubSpot OAuth constants from options
+// Load OAuth credentials from variables.php
+$vars_path = HUBSPOT_WC_SYNC_PATH . 'variables.php';
+$hubspot_vars = file_exists($vars_path) ? include $vars_path : [];
+
 if (!defined('HUBSPOT_CLIENT_ID')) {
-    define('HUBSPOT_CLIENT_ID', get_option('hubspot_client_id', ''));
+    define('HUBSPOT_CLIENT_ID', $hubspot_vars['client_id'] ?? '');
 }
 if (!defined('HUBSPOT_CLIENT_SECRET')) {
-    define('HUBSPOT_CLIENT_SECRET', get_option('hubspot_client_secret', ''));
+    define('HUBSPOT_CLIENT_SECRET', $hubspot_vars['client_secret'] ?? '');
 }
 if (!defined('HUBSPOT_REDIRECT_URI')) {
-    define('HUBSPOT_REDIRECT_URI', site_url('/wp-json/hubspot/v1/oauth/callback'));
+    define('HUBSPOT_REDIRECT_URI', $hubspot_vars['redirect_uri'] ?? site_url('/wp-json/hubspot/v1/oauth/callback'));
 }
 
 // Prepare configuration for global access

--- a/includes/hubspot-settings.php
+++ b/includes/hubspot-settings.php
@@ -15,8 +15,6 @@ class HubSpot_WC_Settings {
     }
 
     public static function register_settings() {
-        register_setting('hubspot_wc_settings', 'hubspot_client_id');
-        register_setting('hubspot_wc_settings', 'hubspot_client_secret');
         register_setting('hubspot_wc_settings', 'hubspot_connected');
         register_setting('hubspot_wc_settings', 'hubspot_auto_create_deal');
         register_setting('hubspot_wc_settings', 'hubspot_pipeline_online');

--- a/variables.php
+++ b/variables.php
@@ -1,0 +1,11 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly
+}
+return [
+    'client_id' => 'cb36d4b5-602e-408d-bcc8-26fa2c3aaf35',
+    'client_secret' => 'a66dab93-5c25-4d68-bd5c-3157d8a55928',
+    'redirect_uri' => 'https://steelmark.com.au/wp-json/hubspot/v1/oauth/callback',
+    'scopes' => 'crm.objects.line_items.read crm.objects.line_items.write oauth conversations.read conversations.write crm.objects.contacts.write e-commerce sales-email-read crm.objects.companies.write crm.objects.companies.read crm.objects.deals.read crm.objects.deals.write crm.objects.contacts.read',
+];
+?>


### PR DESCRIPTION
## Summary
- reintroduce `variables.php` with HubSpot OAuth credentials
- load OAuth configuration from `variables.php` in main plugin
- remove unused client credential settings
- document credential file usage in README

## Testing
- `php -l hubspot-woocommerce-sync.php`
- `php -l includes/hubspot-settings.php`
- `php -l variables.php`


------
https://chatgpt.com/codex/tasks/task_b_685e2d0c81c08326839659258e7b2e90