### PR TITLE
Add admin auth check for HubSpot REST routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Your HubSpot app's **Client ID** and **Client Secret** are loaded from the `vari
 
 ## REST API Endpoints
 
-The plugin provides the following API routes. All routes require an authenticated user with the `manage_options` capability:
+The plugin provides the following API routes. All routes require an authenticated user with the `manage_options` capability. In practice, you must be logged in as an administrator when calling `/start-auth` and `/oauth/callback`. The **Connect HubSpot** link on the plugin settings page opens these routes for you so authentication is handled automatically:
 
 ### Start OAuth Authentication
 `GET /wp-json/hubspot/v1/start-auth`


### PR DESCRIPTION
## Summary
- document that OAuth routes require an authenticated admin session
- provide helper permission callback and enforce it on all REST routes

## Testing
- `php -l includes/hubspot-auth.php`
- `php -l hubspot-woocommerce-sync.php`


------
https://chatgpt.com/codex/tasks/task_b_685e326c6b0883268b8d8b999950cbda