### PR TITLE
Use nonce and cookies in OAuth flow

### DIFF
--- a/includes/hubspot-settings.php
+++ b/includes/hubspot-settings.php
@@ -114,9 +114,23 @@ class HubSpot_WC_Settings {
                 <li><strong><?php esc_html_e('Access Token:', 'hub-woo-sync'); ?></strong> <span id="access-token">...</span></li>
             </ul>
         </div>
-        <a href="<?php echo esc_url($auth_url); ?>" class="button-primary" id="hubspot-auth-button"><?php esc_html_e('Connect HubSpot', 'hub-woo-sync'); ?></a>
+        <a href="#" data-auth-url="<?php echo esc_url($auth_url); ?>" data-nonce="<?php echo esc_attr($nonce); ?>" class="button-primary" id="hubspot-auth-button"><?php esc_html_e('Connect HubSpot', 'hub-woo-sync'); ?></a>
         <script>
         jQuery(function($){
+            $('#hubspot-auth-button').on('click', function(e){
+                e.preventDefault();
+                const url = $(this).data('auth-url');
+                const nonce = $(this).data('nonce');
+                fetch(url, {
+                    credentials: 'include',
+                    headers: { 'X-WP-Nonce': nonce }
+                }).then(function(resp){
+                    if (resp.redirected) {
+                        window.location.href = resp.url;
+                    }
+                });
+            });
+
             function checkHubSpotConnection() {
                 $.post(ajaxurl, { action: 'hubspot_check_connection' }, function(response) {
                     if (typeof response === 'string') {


### PR DESCRIPTION
## Summary
- include `wp_rest` nonce in auth link
- add JS handler to call OAuth endpoint with `fetch()` using `credentials: 'include'`

## Testing
- `bash bin/package.sh`

------
https://chatgpt.com/codex/tasks/task_b_685e3e954e888326b642f9155d33e832