### PR TITLE
Simplify HubSpot auth redirect

### DIFF
--- a/includes/hubspot-settings.php
+++ b/includes/hubspot-settings.php
@@ -114,21 +114,12 @@ class HubSpot_WC_Settings {
                 <li><strong><?php esc_html_e('Access Token:', 'hub-woo-sync'); ?></strong> <span id="access-token">...</span></li>
             </ul>
         </div>
-        <a href="#" data-auth-url="<?php echo esc_url($auth_url); ?>" data-nonce="<?php echo esc_attr($nonce); ?>" class="button-primary" id="hubspot-auth-button"><?php esc_html_e('Connect HubSpot', 'hub-woo-sync'); ?></a>
+        <a href="#" data-auth-url="<?php echo esc_url($auth_url); ?>" class="button-primary" id="hubspot-auth-button"><?php esc_html_e('Connect HubSpot', 'hub-woo-sync'); ?></a>
         <script>
         jQuery(function($){
             $('#hubspot-auth-button').on('click', function(e){
                 e.preventDefault();
-                const url = $(this).data('auth-url');
-                const nonce = $(this).data('nonce');
-                fetch(url, {
-                    credentials: 'include',
-                    headers: { 'X-WP-Nonce': nonce }
-                }).then(function(resp){
-                    if (resp.redirected) {
-                        window.location.href = resp.url;
-                    }
-                });
+                window.location.href = $(this).data('auth-url');
             });
 
             function checkHubSpotConnection() {


### PR DESCRIPTION
## Summary
- remove fetch call from auth button
- redirect browser directly to OAuth start URL with nonce included

## Testing
- `php -l includes/hubspot-settings.php`

------
https://chatgpt.com/codex/tasks/task_b_685e41cd28a88326a5df7fa3afd00f59