### PR TITLE
Fix missing line items handling

### DIFF
--- a/includes/hubspot-functions.php
+++ b/includes/hubspot-functions.php
@@ -111,9 +111,13 @@ function hubwoo_ajax_import_order() {
     $subtotal = 0;
 
     // Line items
-    foreach ($deal['line_items'] as $item_id) {
-        $line_item = fetch_hubspot_line_item($item_id);
-        if (!$line_item) continue;
+    if (empty($deal['line_items'])) {
+        hubwoo_log("[HubSpot] No line items returned for deal {$deal_id}", 'warning');
+        $order->add_order_note("❌ No line items imported from HubSpot deal {$deal_id}");
+    } else {
+        foreach ($deal['line_items'] as $item_id) {
+            $line_item = fetch_hubspot_line_item($item_id);
+            if (!$line_item) continue;
 
         $product_id = wc_get_product_id_by_sku($line_item['sku']);
         $product = $product_id ? wc_get_product($product_id) : false;
@@ -133,6 +137,7 @@ function hubwoo_ajax_import_order() {
         }
 
         $order->add_item($item);
+        }
     }
 
     // Shipping

--- a/includes/manual-actions.php
+++ b/includes/manual-actions.php
@@ -123,9 +123,13 @@ function ubwoosync_manual_sync_hubspot_order() {
         }
     }
 
-    foreach ($deal['line_items'] as $item_id) {
-        $line_item = fetch_hubspot_line_item($item_id);
-        if (!$line_item) continue;
+    if (empty($deal['line_items'])) {
+        hubwoo_log("[HubSpot] No line items returned for deal {$deal_id}", 'warning');
+        $order->add_order_note("❌ No line items imported from HubSpot deal {$deal_id}");
+    } else {
+        foreach ($deal['line_items'] as $item_id) {
+            $line_item = fetch_hubspot_line_item($item_id);
+            if (!$line_item) continue;
 
         $product_id = wc_get_product_id_by_sku($line_item['sku']);
         $item = new WC_Order_Item_Product();
@@ -138,6 +142,7 @@ function ubwoosync_manual_sync_hubspot_order() {
         $item->add_meta_data('Cost', $line_item['price']);
         $item->add_meta_data('SKU', $line_item['sku']);
         $order->add_item($item);
+        }
     }
 
     if (!empty($deal['shipping'])) {


### PR DESCRIPTION
## Summary
- prevent errors when HubSpot deals return no line items
- warn in logs and order notes when no line items are imported

## Testing
- `php -l includes/hubspot-functions.php` *(fails: command not found)*
- `php -l includes/manual-actions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685e748c13ec8326a979adcd02ff91cd