### PR TITLE
Add automatic order completion

### DIFF
--- a/includes/online-order-sync.php
+++ b/includes/online-order-sync.php
@@ -168,3 +168,20 @@ function hubwoosync_create_line_item($name, $price, $quantity, $sku, $gst, $acce
     $data = json_decode(wp_remote_retrieve_body($response), true);
     return $data['id'] ?? null;
 }
+
+// Automatically mark paid online orders as completed if enabled
+add_action('woocommerce_payment_complete', 'hubwoosync_autocomplete_online_order', 100);
+function hubwoosync_autocomplete_online_order($order_id) {
+    if (!get_option('hubspot_autocomplete_online_order')) {
+        return;
+    }
+
+    $order = wc_get_order($order_id);
+    if (!$order || $order->get_meta('order_type') !== 'online') {
+        return;
+    }
+
+    if ($order->has_status('processing')) {
+        $order->update_status('completed', __('Automatically completed', 'hub-woo-sync'));
+    }
+}


### PR DESCRIPTION
## Summary
- add option-controlled hook to auto-complete paid online orders

## Testing
- `php -l includes/online-order-sync.php`

------
https://chatgpt.com/codex/tasks/task_b_6860c06fa65483268b6495ff365e3504