### PR TITLE
Add order cleanup settings

### DIFF
--- a/includes/hubspot-settings.php
+++ b/includes/hubspot-settings.php
@@ -28,6 +28,8 @@ class HubSpot_WC_Settings {
         register_setting('hubspot_wc_settings', 'hubspot_stage_invoice_sent_manual');
         register_setting('hubspot_wc_settings', 'hubspot_stage_invoice_sent_online');
         register_setting('hubspot_wc_settings', 'hubspot_autocomplete_online_order');
+        register_setting('hubspot_wc_settings', 'hubspot_order_cleanup_status');
+        register_setting('hubspot_wc_settings', 'hubspot_order_cleanup_days');
     }
 
     /**


### PR DESCRIPTION
## Summary
- allow configuring order cleanup status and age

## Testing
- `php -l includes/hubspot-settings.php`

------
https://chatgpt.com/codex/tasks/task_b_6860ce0bbbac83269cac42a8081bab8d