### PR TITLE
Add order cleanup cron hook

### DIFF
--- a/hubspot-woocommerce-sync.php
+++ b/hubspot-woocommerce-sync.php
@@ -86,6 +86,7 @@ require_once HUBSPOT_WC_SYNC_PATH . 'includes/send-quote.php';
 require_once HUBSPOT_WC_SYNC_PATH . 'includes/create-object.php';
 require_once HUBSPOT_WC_SYNC_PATH . 'includes/fetch-object.php';
 require_once HUBSPOT_WC_SYNC_PATH . 'includes/hub-order-management.php';
+require_once HUBSPOT_WC_SYNC_PATH . 'includes/order-cleanup.php';
 
 // Initialize plugin settings
 HubSpot_WC_Settings::init();

--- a/includes/order-cleanup.php
+++ b/includes/order-cleanup.php
@@ -1,0 +1,28 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Cleanup old WooCommerce orders based on status and age.
+ */
+function hubwoosync_cleanup_orders() {
+    $status = get_option('hubspot_order_cleanup_status');
+    $days   = absint(get_option('hubspot_order_cleanup_days'));
+    if (!$status || $days <= 0) {
+        return;
+    }
+    $cutoff = strtotime("-{$days} days");
+    $orders = wc_get_orders([
+        'status'       => $status,
+        'date_created' => '<' . gmdate('Y-m-d H:i:s', $cutoff),
+        'limit'        => -1,
+        'return'       => 'ids',
+    ]);
+    foreach ($orders as $id) {
+        wc_delete_order($id);
+    }
+}
+
+add_action('hubspot_order_cleanup_event', 'hubwoosync_cleanup_orders');
+


### PR DESCRIPTION
## Summary
- add order-cleanup logic to clean WooCommerce orders
- include the cleanup file in main plugin

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6860d269c6608326804b8ee775e6c51f