### PR TITLE
Add pipeline cache refresh controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ HubSpot WooCommerce Sync is a WordPress plugin that integrates WooCommerce with 
   * This distinction controls pipeline/stage logic and affects invoice/quote workflows
 
 * **Stage & Pipeline Label Caching**
-  Caches HubSpot pipeline and stage labels from the API to reduce repeated requests and provide readable names in the admin UI.
+  Caches HubSpot pipeline and stage labels from the API to reduce repeated requests and provide readable names in the admin UI. Cached data lives in the `hubspot_cached_pipelines` option and can be refreshed from the **Pipelines** tab using the new **Sync** button.
 
 * **Robust Error Handling and Logging**
 

--- a/includes/hubspot-auth.php
+++ b/includes/hubspot-auth.php
@@ -236,6 +236,10 @@ function steelmark_handle_oauth_callback(WP_REST_Request $request) {
         'expires_at'    => time() + intval($body['expires_in'])
     ], ['%d', '%s', '%s', '%d']);
 
+    if (class_exists('HubSpot_WC_Settings')) {
+        HubSpot_WC_Settings::refresh_pipeline_cache();
+    }
+
     wp_redirect(home_url() . '?hubspot_auth=success');
     exit;
 }

--- a/includes/hubspot-settings.php
+++ b/includes/hubspot-settings.php
@@ -98,6 +98,9 @@ class HubSpot_WC_Settings {
                     self::render_orders_settings();
                 }
                 submit_button();
+                if ($active_tab === 'woocommerce') {
+                    echo '<button class="button" name="hubspot_refresh_pipelines" value="1">' . esc_html__('Sync', 'hub-woo-sync') . '</button>';
+                }
                 ?>
             </form>
         </div>
@@ -264,8 +267,20 @@ class HubSpot_WC_Settings {
     }
 
     public static function maybe_refresh_cache_on_save() {
-        if (isset($_GET['page'], $_GET['settings-updated']) && $_GET['page'] === 'hubspot-woocommerce-sync') {
+        if (!empty($_POST['hubspot_refresh_pipelines'])) {
             self::refresh_pipeline_cache();
+            set_transient('hubspot_pipelines_synced', 1, 30);
+        } elseif (isset($_GET['page'], $_GET['settings-updated']) && $_GET['page'] === 'hubspot-woocommerce-sync') {
+            self::refresh_pipeline_cache();
+        }
+
+        add_action('admin_notices', [__CLASS__, 'maybe_display_sync_notice']);
+    }
+
+    public static function maybe_display_sync_notice() {
+        if (get_transient('hubspot_pipelines_synced')) {
+            echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__('HubSpot pipelines refreshed.', 'hub-woo-sync') . '</p></div>';
+            delete_transient('hubspot_pipelines_synced');
         }
     }
 


### PR DESCRIPTION
## Summary
- refresh cached pipelines when OAuth tokens are stored
- provide a **Sync** button in the Pipelines tab
- allow manual refresh via POST and show an admin notice
- document the cache option and new button in README

## Testing
- `php -l includes/hubspot-auth.php`
- `php -l includes/hubspot-settings.php`


------
https://chatgpt.com/codex/tasks/task_b_6860dd7dd7688326bd4c45671ed3f475