### PR TITLE
Clarify plugin data retention

### DIFF
--- a/hubspot-woocommerce-sync.php
+++ b/hubspot-woocommerce-sync.php
@@ -10,6 +10,10 @@ License: GPL-3.0
 Text Domain: hubspot-woocommerce-sync
 */
 
+// Data retention note: plugin deactivation or update does not remove any
+// HubSpot options or the `hubspot_tokens` table. Those are only deleted when
+// uninstall.php runs after the plugin is deleted.
+
 if (!defined('ABSPATH')) {
     exit;
 }
@@ -98,6 +102,8 @@ register_deactivation_hook(__FILE__, 'hubwoo_deactivation');
 /**
  * Plugin activation callback.
  * Creates the `hubspot_tokens` table and schedules a token refresh cron.
+ * No data is removed during activation or deactivation; stored tokens and
+ * options remain intact.
  */
 function hubwoo_activation() {
     global $wpdb;
@@ -127,7 +133,8 @@ function hubwoo_activation() {
 
 /**
  * Plugin deactivation callback.
- * Clears the scheduled token refresh cron.
+ * Clears scheduled cron events. Data and tables are preserved so the
+ * plugin can be reactivated without reconnecting.
  */
 function hubwoo_deactivation() {
     wp_clear_scheduled_hook('hubspot_token_refresh_event');

--- a/uninstall.php
+++ b/uninstall.php
@@ -7,7 +7,8 @@ if (!defined('WP_UNINSTALL_PLUGIN')) {
 global $wpdb;
 $table_name = $wpdb->prefix . 'hubspot_tokens';
 
-// Delete stored OAuth tokens
+// This file runs only when the plugin is deleted. Drop the tokens table
+// so all stored OAuth data is removed.
 $wpdb->query("DROP TABLE IF EXISTS {$table_name}");
 
 ?>


### PR DESCRIPTION
## Summary
- explain that data is kept on deactivation/update
- clarify activation/deactivation callbacks
- document uninstall behaviour

## Testing
- `php -l hubspot-woocommerce-sync.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6860e0df70388326b7ec874fa5f84f87