### PR TITLE
Update plugin uninstall cleanup

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -10,4 +10,32 @@ $table_name = $wpdb->prefix . 'hubspot_tokens';
 // Delete stored OAuth tokens
 $wpdb->query("DROP TABLE IF EXISTS {$table_name}");
 
+// Delete plugin options
+$options = [
+    'hubspot_connected',
+    'hubspot_auto_create_deal',
+    'hubspot_pipeline_online',
+    'hubspot_pipeline_manual',
+    'hubspot_pipeline_sync_enabled',
+    'hubspot_status_stage_mapping',
+    'hubspot_stage_quote_sent_manual',
+    'hubspot_stage_quote_sent_online',
+    'hubspot_stage_quote_accepted_manual',
+    'hubspot_stage_quote_accepted_online',
+    'hubspot_stage_invoice_sent_manual',
+    'hubspot_stage_invoice_sent_online',
+    'hubspot_autocomplete_online_order',
+    'hubspot_order_cleanup_status',
+    'hubspot_order_cleanup_days',
+    'hubspot_cached_pipelines',
+];
+
+foreach ($options as $option) {
+    delete_option($option);
+}
+
+// Clear scheduled events
+wp_clear_scheduled_hook('hubspot_token_refresh_event');
+wp_clear_scheduled_hook('hubspot_order_cleanup_event');
+
 ?>


### PR DESCRIPTION
## Summary
- delete stored options when uninstalling
- clear scheduled events

## Testing
- `php -l uninstall.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6860e02c3be083269259659ec5cb0e9b