### PR TITLE
Fix function names in manual-actions

### DIFF
--- a/includes/manual-actions.php
+++ b/includes/manual-actions.php
@@ -33,7 +33,7 @@ function hubwoosync_send_quote_email() {
  * Send invoice email and update HubSpot deal
  */
 add_action('wp_ajax_hubwoosync_send_invoice_email', 'hubwoosync_send_invoice_email');
-function ubwoosync_send_invoice_email() {
+function hubwoosync_send_invoice_email() {
     check_ajax_referer('send_invoice_email_nonce', 'security');
 
     if (! current_user_can('manage_woocommerce')) {
@@ -75,7 +75,7 @@ function ubwoosync_send_invoice_email() {
  * Manual sync of WooCommerce order from HubSpot deal
  */
 add_action('wp_ajax_hubwoosync_manual_sync_hubspot_order', 'hubwoosync_manual_sync_hubspot_order');
-function ubwoosync_manual_sync_hubspot_order() {
+function hubwoosync_manual_sync_hubspot_order() {
     check_ajax_referer('hubwoosync_manual_sync_hubspot_order_nonce', 'security');
 
     $order_id = absint($_POST['order_id']);


### PR DESCRIPTION
## Summary
- rename `ubwoosync_send_invoice_email()` to `hubwoosync_send_invoice_email()`
- rename `ubwoosync_manual_sync_hubspot_order()` to `hubwoosync_manual_sync_hubspot_order()`

## Testing
- `bash bin/package.sh`
- `php -l includes/manual-actions.php`

------
https://chatgpt.com/codex/tasks/task_b_686212f525848326a8eb6d2b21539949