### PR TITLE
Secure get-token route

### DIFF
--- a/includes/hubspot-auth.php
+++ b/includes/hubspot-auth.php
@@ -20,13 +20,15 @@ add_action('rest_api_init', function () {
         },
     ]);
 
-    register_rest_route('hubspot/v1', '/get-token', [
-        'methods'             => 'GET',
-        'callback'            => 'get_stored_token',
-        'permission_callback' => function() {
-            return current_user_can('manage_options');
-        },
-    ]);
+    if (defined('HUBSPOT_WC_DEBUG') && HUBSPOT_WC_DEBUG) {
+        register_rest_route('hubspot/v1', '/get-token', [
+            'methods'             => 'GET',
+            'callback'            => 'get_stored_token',
+            'permission_callback' => function() {
+                return current_user_can('manage_options');
+            },
+        ]);
+    }
 });
 
 /**


### PR DESCRIPTION
## Summary
- restrict the `/hubspot/v1/get-token` REST endpoint to only load when `HUBSPOT_WC_DEBUG` is true

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68621548aa988326992092d478f1905c