### PR TITLE
Update mapping options for order sync

### DIFF
--- a/includes/hubspot-functions.php
+++ b/includes/hubspot-functions.php
@@ -195,9 +195,10 @@ function hubwoo_ajax_import_order() {
     $order->save();
 
     // Sync HubSpot Deal
-    $status_key = 'manual_wc-' . $order->get_status();
-    $mapping = get_option('hubspot_status_stage_mapping', []);
-    $new_stage = $mapping[$status_key] ?? null;
+    $status    = $order->get_status();
+    $status_key = 'manual_wc-' . $status;
+    $mapping   = get_option('hubspot-manual-mapping', []);
+    $new_stage = $mapping[$status] ?? null;
 
     $payload = [
         'properties' => [

--- a/includes/hubspot-settings.php
+++ b/includes/hubspot-settings.php
@@ -425,8 +425,15 @@ class HubSpot_WC_Settings {
         $order = wc_get_order($order_id);
         if (!$order) return;
 
+        $online_map = get_option('hubspot-online-mapping', []);
+        $manual_map = get_option('hubspot-manual-mapping', []);
+
         $is_manual = get_post_meta($order_id, 'order_type', true) === 'manual';
-        $status_key = ($is_manual ? 'manual_wc' : 'online_wc') . '-' . $new_status;
+        if ($is_manual || (!isset($online_map[$new_status]) && isset($manual_map[$new_status]))) {
+            $status_key = 'manual_wc-' . $new_status;
+        } else {
+            $status_key = 'online_wc-' . $new_status;
+        }
 
         if (function_exists('sync_order_to_hubspot_deal_stage')) {
             sync_order_to_hubspot_deal_stage($order, $status_key);

--- a/includes/manual-actions.php
+++ b/includes/manual-actions.php
@@ -201,10 +201,11 @@ function hubwoosync_create_hubspot_deal_manual() {
         wp_send_json_error('Manual pipeline not configured.');
     }
 
-    $token = manage_hubspot_access_token();
-    $status_key = 'manual_wc-' . $order->get_status();
-    $mapping = get_option('hubspot_status_stage_mapping', []);
-    $stage_id = $mapping[$status_key] ?? hubspot_get_cached_first_stage_of_pipeline($pipeline_id);
+    $token      = manage_hubspot_access_token();
+    $status     = $order->get_status();
+    $status_key = 'manual_wc-' . $status;
+    $mapping    = get_option('hubspot-manual-mapping', []);
+    $stage_id   = $mapping[$status] ?? hubspot_get_cached_first_stage_of_pipeline($pipeline_id);
 
     $contact_id = hubspot_get_or_create_contact_id_from_order($order, $token);
     $deal_id = hubspot_create_deal_from_order($order, $pipeline_id, $stage_id, $contact_id, $token);

--- a/includes/manual-order-sync.php
+++ b/includes/manual-order-sync.php
@@ -99,11 +99,11 @@ function hubwoosync_set_manual_pipeline_meta($order_id, $order){
     }
 
     if (!$order->get_meta('hubspot_pipeline_id')) {
-        $pipeline_id  = get_option('hubspot_pipeline_manual');
-        $labels       = get_hubspot_pipeline_and_stage_labels();
-        $status_key   = 'manual_wc-' . $order->get_status();
-        $mapping      = get_option('hubspot_status_stage_mapping', []);
-        $stage_id     = $mapping[$status_key] ?? hubspot_get_cached_first_stage_of_pipeline($pipeline_id);
+        $pipeline_id = get_option('hubspot_pipeline_manual');
+        $labels      = get_hubspot_pipeline_and_stage_labels();
+        $status      = $order->get_status();
+        $mapping     = get_option('hubspot-manual-mapping', []);
+        $stage_id    = $mapping[$status] ?? hubspot_get_cached_first_stage_of_pipeline($pipeline_id);
 
         $order->update_meta_data('hubspot_pipeline_id', $pipeline_id);
         $order->update_meta_data('hubspot_pipeline', $labels['pipelines'][$pipeline_id] ?? $pipeline_id);

--- a/includes/online-order-sync.php
+++ b/includes/online-order-sync.php
@@ -60,10 +60,10 @@ function hubwoosync_auto_sync_online_order($order_id) {
         return;
     }
 
-    $status = $order->get_status();
-    $status_key = "online_wc-{$status}";
-    $mapping = get_option('hubspot_status_stage_mapping', []);
-    $deal_stage = $mapping[$status_key] ?? '';
+    $status     = $order->get_status();
+    $status_key = 'online_wc-' . $status;
+    $mapping    = get_option('hubspot-online-mapping', []);
+    $deal_stage = $mapping[$status] ?? '';
 
     if (!$deal_stage) {
         $deal_stage = hubspot_get_first_stage_of_pipeline($pipeline_id, $access_token);


### PR DESCRIPTION
## Summary
- read new hubspot-online-mapping and hubspot-manual-mapping options
- adjust order status sync helper
- pick fallback stages from cached deal stage lists

## Testing
- `php -l includes/hubspot-pipelines.php`
- `php -l includes/online-order-sync.php`
- `php -l includes/manual-actions.php`
- `php -l includes/manual-order-sync.php`
- `php -l includes/hubspot-functions.php`
- `php -l includes/hubspot-settings.php`


------
https://chatgpt.com/codex/tasks/task_b_686370dfb0788326b8181abcf6d2f664