### PR TITLE
Handle legacy stage mapping option

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -33,6 +33,7 @@ $options = [
     'hubspot_order_cleanup_days',
     'hubspot_cached_pipelines',
     'hubspot_oauth_state',
+    'hubspot_status_stage_mapping',
 ];
 
 foreach ($options as $option) {


### PR DESCRIPTION
## Summary
- migrate old `hubspot_status_stage_mapping` on plugin load and activation
- clean up legacy stage option during uninstall

## Testing
- `GITHUB_OUTPUT=/tmp/gh_out bash bin/package.sh`

------
https://chatgpt.com/codex/tasks/task_b_6864d31211508326a550f0e57a6b050a