### PR TITLE
Fix pipeline stage dropdown labels

### DIFF
--- a/includes/hubspot-settings.php
+++ b/includes/hubspot-settings.php
@@ -204,8 +204,8 @@ class HubSpot_WC_Settings {
         $online_map     = get_option('hubspot-online-mapping', []);
         $manual_map     = get_option('hubspot-manual-mapping', []);
 
-        $online_stages = get_option('hubspot-online-deal-stages', $pipelines[$online_pipeline]['stages'] ?? []);
-        $manual_stages = get_option('hubspot-manual-deal-stages', $pipelines[$manual_pipeline]['stages'] ?? []);
+        $online_stages = $pipelines[$online_pipeline]['stages'] ?? [];
+        $manual_stages = $pipelines[$manual_pipeline]['stages'] ?? [];
 
         echo '<h3>' . esc_html__('HubSpot Pipelines Settings', 'hub-woo-sync') . '</h3>';
 


### PR DESCRIPTION
## Summary
- use the stage lists from `hubspot_cached_pipelines` when rendering dropdowns

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6864d41336a483268b38023b1361f9d2