### PR TITLE
Fix stage cache

### DIFF
--- a/includes/hubspot-settings.php
+++ b/includes/hubspot-settings.php
@@ -335,10 +335,16 @@ class HubSpot_WC_Settings {
             $manual = get_option('hubspot_pipeline_manual');
 
             if ($online && isset($pipelines[$online]['stages'])) {
-                update_option('hubspot-online-deal-stages', array_keys($pipelines[$online]['stages']));
+                update_option(
+                    'hubspot-online-deal-stages',
+                    array_fill_keys(array_keys($pipelines[$online]['stages']), true)
+                );
             }
             if ($manual && isset($pipelines[$manual]['stages'])) {
-                update_option('hubspot-manual-deal-stages', array_keys($pipelines[$manual]['stages']));
+                update_option(
+                    'hubspot-manual-deal-stages',
+                    array_fill_keys(array_keys($pipelines[$manual]['stages']), true)
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary
- store stage cache as associative arrays keyed by stage ID

## Testing
- `php -l includes/hubspot-settings.php`
- `php -l includes/hubspot-pipelines.php`


------
https://chatgpt.com/codex/tasks/task_b_6864d82f87948326b188a40b02eb430f