### PR TITLE
Remove credentials and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,15 +118,23 @@ HubSpot WooCommerce Sync is a WordPress plugin that integrates WooCommerce with 
 2. Upload the `.zip` file to WordPress via **Plugins → Add New → Upload Plugin**.
 3. Activate the plugin.
 
+
 ### Using GitHub Updater
 1. Install the [GitHub Updater](https://github.com/afragen/github-updater) plugin.
 2. Add the repository URL in the GitHub Updater settings.
 3. The plugin will now receive updates directly from GitHub.
 
+## Creating a Private HubSpot App
+
+1. Sign in to the [HubSpot Developer Portal](https://developers.hubspot.com/).
+2. Create a **Private App** and note the generated **Client ID** and **Client Secret**.
+3. Add your site's OAuth **Redirect URI** (usually `https://yoursite.com/wp-json/hubspot/v1/oauth/callback`).
+4. Copy these values into the plugin's `variables.php` file.
+
 ## Setup & Authentication
 
 1. **Go to WordPress Admin → HubSpot Sync**.
-2. Ensure the plugin's `variables.php` file contains your HubSpot **Client ID** and **Client Secret**.
+2. Ensure the plugin's `variables.php` file contains your HubSpot **Client ID**, **Client Secret**, and **Redirect URI** from your private app.
 3. Click the **Connect HubSpot** button and follow the authorization flow.
 4. Once authenticated, select a **pipeline for online orders** and a separate
    **pipeline for manual orders** under the **Pipelines** tab.
@@ -142,7 +150,7 @@ creating an order in the admin, go to **HubSpot → Order Management** and click
 the **Create Deal** button to push the order to HubSpot.
 
 ### HubSpot App Credentials
-Your HubSpot app's **Client ID** and **Client Secret** are loaded from the `variables.php` file in the plugin directory.
+Your HubSpot app's **Client ID**, **Client Secret**, and **Redirect URI** are loaded from the `variables.php` file in the plugin directory.
 
 ## REST API Endpoints
 

--- a/includes/manual-actions.php
+++ b/includes/manual-actions.php
@@ -2,7 +2,7 @@
 /**
  * Manual HubSpot Sync Actions
  *
- * @package Steelmark
+ * @package HubSpotWooCommerceSync
  */
 
 if (!defined('ABSPATH')) exit;

--- a/includes/send-quote.php
+++ b/includes/send-quote.php
@@ -24,7 +24,7 @@ function send_quote($order_id) {
         'key'          => $order->get_order_key(),
     ], site_url('/'));
 
-    $subject = sprintf('[Steelmark Quote] Order #%s', $order->get_order_number());
+    $subject = sprintf('[Your Store Quote] Order #%s', $order->get_order_number());
 
     ob_start();
     wc_get_template('emails/email-header.php', [], '', get_stylesheet_directory() . '/woocommerce/');
@@ -40,9 +40,9 @@ function send_quote($order_id) {
     $headers = [
         'MIME-Version: 1.0',
         'Content-Type: text/html; charset=UTF-8',
-        'From: Steelmark <website@steelmark.com.au>',
-        'Reply-To: website@steelmark.com.au',
-        'Return-Path: website@steelmark.com.au',
+        'From: Your Store <noreply@example.com>',
+        'Reply-To: noreply@example.com',
+        'Return-Path: noreply@example.com',
         'X-Mailer: PHP/' . phpversion(),
         'X-Priority: 3 (Normal)',
     ];
@@ -84,7 +84,7 @@ function send_invoice($order_id) {
     $order_key = $order->get_order_key();
     $payment_url = site_url("/checkout/order-pay/{$order_id}/?key={$order_key}");
 
-    $subject = sprintf('[Steelmark Invoice] Order #%s is ready for payment', $order->get_order_number());
+    $subject = sprintf('[Your Store Invoice] Order #%s is ready for payment', $order->get_order_number());
 
     ob_start();
     wc_get_template('emails/email-header.php', [], '', get_stylesheet_directory() . '/woocommerce/');
@@ -95,9 +95,9 @@ function send_invoice($order_id) {
     $headers = [
         'MIME-Version: 1.0',
         'Content-Type: text/html; charset=UTF-8',
-        'From: Steelmark <website@steelmark.com.au>',
-        'Reply-To: website@steelmark.com.au',
-        'Return-Path: website@steelmark.com.au',
+        'From: Your Store <noreply@example.com>',
+        'Reply-To: noreply@example.com',
+        'Return-Path: noreply@example.com',
         'X-Mailer: PHP/' . phpversion(),
         'X-Priority: 3 (Normal)'
     ];

--- a/variables.php
+++ b/variables.php
@@ -3,9 +3,10 @@ if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly
 }
 return [
-    'client_id' => 'cb36d4b5-602e-408d-bcc8-26fa2c3aaf35',
-    'client_secret' => 'a66dab93-5c25-4d68-bd5c-3157d8a55928',
-    'redirect_uri' => 'https://steelmark.com.au/wp-json/hubspot/v1/oauth/callback',
-    'scopes' => 'crm.objects.line_items.read crm.objects.line_items.write oauth conversations.read conversations.write crm.objects.contacts.write e-commerce sales-email-read crm.objects.companies.write crm.objects.companies.read crm.objects.deals.read crm.objects.deals.write crm.objects.contacts.read',
+    // Insert your HubSpot app credentials here. See README for details.
+    'client_id'     => '',
+    'client_secret' => '',
+    'redirect_uri'  => '',
+    'scopes'        => 'crm.objects.line_items.read crm.objects.line_items.write oauth conversations.read conversations.write crm.objects.contacts.write e-commerce sales-email-read crm.objects.companies.write crm.objects.companies.read crm.objects.deals.read crm.objects.deals.write crm.objects.contacts.read',
 ];
 ?>


### PR DESCRIPTION
## Summary
- strip sample credentials from `variables.php`
- generalize email addresses in send-quote templates
- update manual-actions header
- document creating a private HubSpot app in the README

## Testing
- `env GITHUB_OUTPUT=/tmp/github_output bash bin/package.sh`

------
https://chatgpt.com/codex/tasks/task_b_68659f9132288326aef65d3a6cbda8eb