### PR TITLE
Initialize default field mapping options

### DIFF
--- a/hubspot-woocommerce-sync.php
+++ b/hubspot-woocommerce-sync.php
@@ -172,3 +172,49 @@ function hubwoo_migrate_legacy_stage_mapping() {
 
 // Trigger migration on each page load in case the plugin was updated without reactivation
 add_action('plugins_loaded', 'hubwoo_migrate_legacy_stage_mapping');
+
+/**
+ * Initialize default field mappings on first install or upgrade.
+ */
+function hubwoo_init_default_field_mappings() {
+    $deal_defaults = [
+        'shipping'                => 'shipping_total',
+        'deal_notes'              => 'customer_note',
+        'address_line_1'          => 'billing_address_1',
+        'city'                    => 'billing_city',
+        'postcode'                => 'billing_postcode',
+        'state'                   => 'billing_state',
+        'country_region'          => 'billing_country',
+        'address_line_1_shipping' => 'shipping_address_1',
+        'city_shipping'           => 'shipping_city',
+        'postcode_shipping'       => 'shipping_postcode',
+        'state_shipping'          => 'shipping_state',
+        'country_region_shipping' => 'shipping_country',
+        'first_name_shipping'     => 'shipping_first_name',
+        'last_name_shipping'      => 'shipping_last_name',
+        'payway_order_number'     => '_payway_api_order_number',
+        'phone_shipping'          => 'shipping_phone',
+    ];
+
+    $contact_defaults = [
+        'email'     => 'billing_email',
+        'firstname' => 'billing_first_name',
+        'lastname'  => 'billing_last_name',
+        'phone'     => 'billing_phone',
+    ];
+
+    $company_defaults = [
+        'name' => 'billing_company',
+    ];
+
+    if (!get_option('hubspot_deal_field_map')) {
+        update_option('hubspot_deal_field_map', $deal_defaults);
+    }
+    if (!get_option('hubspot_contact_field_map')) {
+        update_option('hubspot_contact_field_map', $contact_defaults);
+    }
+    if (!get_option('hubspot_company_field_map')) {
+        update_option('hubspot_company_field_map', $company_defaults);
+    }
+}
+add_action('plugins_loaded', 'hubwoo_init_default_field_mappings');

--- a/includes/hubspot-settings.php
+++ b/includes/hubspot-settings.php
@@ -710,22 +710,29 @@ class HubSpot_WC_Settings {
      */
     public static function sanitize_field_map($input) {
         $output = [];
-        $props  = $input['property'] ?? [];
-        $fields = $input['field'] ?? [];
-        $metas  = $input['meta'] ?? [];
 
-        $count = max(count($props), count($fields));
+        // Support both legacy array format from the settings form and direct key => value arrays
+        if (isset($input['property'])) {
+            $props  = $input['property'] ?? [];
+            $fields = $input['field'] ?? [];
+            $count  = max(count($props), count($fields));
 
-        for ($i = 0; $i < $count; $i++) {
-            $prop  = sanitize_text_field($props[$i] ?? '');
-            $field = sanitize_text_field($fields[$i] ?? '');
-            $meta  = sanitize_text_field($metas[$i] ?? '');
+            for ($i = 0; $i < $count; $i++) {
+                $prop  = sanitize_text_field($props[$i] ?? '');
+                $field = sanitize_text_field($fields[$i] ?? '');
 
-            if ($prop && $field) {
-                $output[$prop] = [
-                    'field' => $field,
-                    'meta'  => $field === 'meta' ? $meta : '',
-                ];
+                if ($prop && $field) {
+                    $output[$prop] = $field;
+                }
+            }
+        } elseif (is_array($input)) {
+            foreach ($input as $prop => $field) {
+                $prop  = sanitize_text_field($prop);
+                $field = sanitize_text_field($field);
+
+                if ($prop && $field) {
+                    $output[$prop] = $field;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- fill new field mapping options with default values on upgrade
- store property mapping options as key=>value arrays for safety

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6865e30d40a88326a8b8f7d6a5def3df